### PR TITLE
Feature: manage applications

### DIFF
--- a/apps/apprm/lib/features/application/pages/app_home_page.dart
+++ b/apps/apprm/lib/features/application/pages/app_home_page.dart
@@ -1,0 +1,141 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:apprm/bootstrap/powersync.dart';
+import 'package:apprm/constants/color.dart';
+import 'package:apprm/router.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+class AppHomePage extends StatefulWidget {
+  const AppHomePage({super.key, required this.appId});
+
+  final String appId;
+
+  @override
+  State<AppHomePage> createState() => _AppHomePageState();
+}
+
+class _AppHomePageState extends State<AppHomePage> {
+  late final List<({IconData icon, String title, String route})> objectListData;
+
+  @override
+  void initState() {
+    objectListData = [
+      (
+        icon: PhosphorIconsFill.asterisk,
+        title: 'Requirements',
+        route: '/app/${widget.appId}/internal/requirements'
+      ),
+      (
+        icon: PhosphorIconsFill.treeStructure,
+        title: 'Data Model',
+        route: '/app/${widget.appId}/internal/data_objects'
+      ),
+      (
+        icon: PhosphorIconsFill.chalkboard,
+        title: 'Screens',
+        route: '/app/${widget.appId}/internal/screens'
+      ),
+      (
+        icon: PhosphorIconsFill.books,
+        title: 'User Stories',
+        route: '/app/${widget.appId}/internal/user_stories'
+      )
+    ];
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundColor,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        automaticallyImplyLeading: true,
+        centerTitle: false,
+        title: const Text('Home'),
+        actions: [
+          QueryBuilder<int>(
+            query: Query(
+              key: ["notification", "list", "count"],
+              queryFn: () async => 0,
+              config: QueryConfig(
+                cacheDuration: const Duration(seconds: 1),
+                refetchDuration: const Duration(seconds: 1),
+              ),
+            ),
+            builder: (context, state) {
+              return Stack(
+                children: [
+                  IconButton(
+                    onPressed: () async {
+                      NotificationRoute().push(context);
+                    },
+                    icon: const Icon(PhosphorIconsBold.dog),
+                  ),
+                  if (state.data != null && state.data! > 0)
+                    const Positioned(
+                      top: 14,
+                      right: 14,
+                      child: CircleAvatar(
+                        radius: 4,
+                        backgroundColor: Colors.red,
+                      ),
+                    ),
+                ],
+              );
+            },
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: IconButton(
+              onPressed: () async {
+                await logout();
+                if (context.mounted) {
+                  const AuthPageRoute().pushReplacement(context);
+                }
+              },
+              icon: const Icon(PhosphorIconsBold.signOut),
+            ),
+          )
+        ],
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemBuilder: (_, idx) {
+          final objectData = objectListData[idx];
+          return ListTile(
+            onTap: () {
+              context.push(objectData.route);
+            },
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            contentPadding: const EdgeInsets.symmetric(
+              vertical: 12,
+              horizontal: 16,
+            ),
+            selected: true,
+            selectedTileColor: Colors.white,
+            leading: CircleAvatar(
+              backgroundColor: AppColors.primaryColor.withOpacity(0.1),
+              child: Icon(
+                objectData.icon,
+                color: AppColors.primaryColor,
+                size: 24,
+              ),
+            ),
+            title: Text(objectData.title),
+            trailing: const Icon(
+              PhosphorIconsBold.caretRight,
+              size: 20,
+            ),
+          );
+        },
+        separatorBuilder: (_, idx) => const SizedBox(height: 8),
+        itemCount: objectListData.length,
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/application/pages/application_adding_page.dart
+++ b/apps/apprm/lib/features/application/pages/application_adding_page.dart
@@ -1,0 +1,32 @@
+import '../../common_object/widgets/managing/object_adding_wrapper.dart';
+import 'package:flutter/material.dart';
+
+class ApplicationAddingPage extends StatelessWidget {
+  const ApplicationAddingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const ObjectAddingWrapper(
+      objectType: 'applications',
+      objectLabel: 'application',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    );
+  }
+}

--- a/apps/apprm/lib/features/application/pages/application_listing_page.dart
+++ b/apps/apprm/lib/features/application/pages/application_listing_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../constants/color.dart';
+import '../../common_object/entities/object_item.dart';
+import '../../common_object/mappers/application_mapper.dart';
+import '../../common_object/widgets/listing/object_list_wrapper.dart';
+import '../../object/widgets/generic_item_card.dart';
+import '../../object/widgets/generic_list_empty.dart';
+import '../../../router.dart';
+
+class ApplicationListingPage extends StatefulWidget {
+  const ApplicationListingPage({super.key});
+
+  @override
+  State<ApplicationListingPage> createState() => _ApplicationListingPageState();
+}
+
+class _ApplicationListingPageState extends State<ApplicationListingPage> {
+  final listWrapperKey = GlobalKey<ObjectListWrapperState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundColor,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: false,
+        title: const Text('Applications'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: IconButton.filled(
+              onPressed: () async {
+                await ApplicationAddingRoute().push(context);
+                listWrapperKey.currentState?.listKey.currentState?.onRefreshList();
+              },
+              icon: const Icon(PhosphorIconsBold.plus),
+              style: IconButton.styleFrom(
+                backgroundColor: AppColors.primaryColor,
+                foregroundColor: Colors.white,
+              ),
+            ),
+          )
+        ],
+      ),
+      body: ObjectListWrapper(
+        key: listWrapperKey,
+        objectType: 'applications',
+        mapperFn: ApplicationToObjectItemMapper.fromJson,
+        itemCardBuilder: (item) => GenericItemCard(item: item),
+        emptyBuilder: () => const GenericListEmpty(),
+        sortFields: const [(key: 'name', label: 'Name')],
+        filterFields: const [],
+        searchFields: const ['name'],
+        onDetailNavigateFn: (id) {
+          AppHomeRoute(appId: id).push(context);
+        },
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/application.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/application.dart
@@ -1,0 +1,34 @@
+class Application {
+  final String id;
+  final DateTime createdAt;
+  final DateTime? updatedAt;
+  final String? name;
+  final String? description;
+
+  Application({
+    required this.id,
+    required this.createdAt,
+    this.updatedAt,
+    this.name,
+    this.description,
+  });
+
+  factory Application.fromJson(Map<String, dynamic> json) {
+    return Application(
+      id: json['id'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt:
+          json['updated_at'] != null ? DateTime.parse(json['updated_at']) : null,
+      name: json['name'] as String?,
+      description: json['description'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'created_at': createdAt.toIso8601String(),
+        'updated_at': updatedAt?.toIso8601String(),
+        'name': name,
+        'description': description,
+      };
+}

--- a/apps/apprm/lib/features/common_object/mappers/application_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/application_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/application.dart';
+
+class ApplicationToObjectItemMapper {
+  static ObjectItem fromModel(Application item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.name ?? '',
+      subTitle: item.description ?? '',
+      sortFields: [
+        (key: 'name', label: 'Name'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(Application.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/listing/object_list_wrapper.dart
+++ b/apps/apprm/lib/features/common_object/widgets/listing/object_list_wrapper.dart
@@ -22,6 +22,8 @@ class ObjectListWrapper extends ConsumerStatefulWidget {
     required this.filterFields,
     required this.searchFields,
     required this.onDetailNavigateFn,
+    this.initialFilterValues,
+    this.initialSortValues,
   });
 
   final String objectType;
@@ -32,6 +34,8 @@ class ObjectListWrapper extends ConsumerStatefulWidget {
   final List<FilterField> filterFields;
   final List<String> searchFields;
   final void Function(String itemId) onDetailNavigateFn;
+  final Map<String, String?>? initialFilterValues;
+  final Map<String, String?>? initialSortValues;
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() =>
@@ -41,9 +45,18 @@ class ObjectListWrapper extends ConsumerStatefulWidget {
 class ObjectListWrapperState extends ConsumerState<ObjectListWrapper> {
   final listKey = GlobalKey<ObjectListState>();
 
-  final sortValuesNotifier = ValueNotifier<Map<String, String?>>({});
-  final filterValuesNotifier = ValueNotifier<Map<String, String?>>({});
+  late final ValueNotifier<Map<String, String?>> sortValuesNotifier;
+  late final ValueNotifier<Map<String, String?>> filterValuesNotifier;
   final searchValueNotifier = ValueNotifier<String?>(null);
+
+  @override
+  void initState() {
+    sortValuesNotifier =
+        ValueNotifier<Map<String, String?>>(widget.initialSortValues ?? {});
+    filterValuesNotifier =
+        ValueNotifier<Map<String, String?>>(widget.initialFilterValues ?? {});
+    super.initState();
+  }
 
   @override
   void dispose() {

--- a/apps/apprm/lib/features/common_object/widgets/managing/object_adding_wrapper.dart
+++ b/apps/apprm/lib/features/common_object/widgets/managing/object_adding_wrapper.dart
@@ -18,11 +18,13 @@ class ObjectAddingWrapper extends ConsumerStatefulWidget {
     required this.objectType,
     required this.objectLabel,
     required this.inputFields,
+    this.extraData,
   });
 
   final String objectType;
   final String objectLabel;
   final List<InputField> inputFields;
+  final Map<String, dynamic>? extraData;
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() =>
@@ -64,9 +66,13 @@ class _ObjectAddingWrapperState extends ConsumerState<ObjectAddingWrapper> {
                 if (formGroup.valid) {
                   try {
                     EasyLoading.show(status: 'Creating...');
+                    final data = {
+                      ...formGroup.value,
+                      if (widget.extraData != null) ...widget.extraData!,
+                    };
                     await createObjectMutation.mutate(CreateObjectUseCaseParams(
                       objectType: widget.objectType,
-                      data: formGroup.value,
+                      data: data,
                     ));
                     CachedQuery.instance.refetchQueries(
                       keys: [widget.objectType, "list"],

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -258,6 +258,7 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
   Widget build(BuildContext context) {
     final objectTypeParam =
         GoRouterState.of(context).pathParameters['objectType']!;
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectAddingWrapper(
@@ -274,6 +275,7 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
                   ))
               .toList() ??
           [],
+      extraData: {'app_id': appIdParam},
     );
   }
 }

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -90,6 +90,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
     final objectTypeParam =
         GoRouterState.of(context).pathParameters['objectType']!;
     final objectIdParam = GoRouterState.of(context).pathParameters['objectId']!;
+    final appIdParam = GoRouterState.of(context).pathParameters['appId'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectDetailWrapper(
@@ -102,6 +103,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
           [],
       onEditingNavigateFn: () {
         ObjectUpdatingRoute(
+          appId: appIdParam!,
           objectType: objectTypeParam,
           objectId: objectIdParam,
         ).push(context);

--- a/apps/apprm/lib/features/object/pages/object_listing_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_listing_page.dart
@@ -153,6 +153,7 @@ class _ObjectListingPageState extends State<ObjectListingPage> {
   Widget build(BuildContext context) {
     final objectTypeParam =
         GoRouterState.of(context).pathParameters['objectType']!;
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
     final objectData = objectDataMap[objectTypeParam];
 
     return Scaffold(
@@ -175,8 +176,10 @@ class _ObjectListingPageState extends State<ObjectListingPage> {
                     ),
                   );
                 } else {
-                  await ObjectAddingRoute(objectType: objectTypeParam)
-                      .push(context);
+                  await ObjectAddingRoute(
+                    appId: appIdParam,
+                    objectType: objectTypeParam,
+                  ).push(context);
                 }
 
                 listWrapperKey.currentState?.listKey.currentState
@@ -210,8 +213,10 @@ class _ObjectListingPageState extends State<ObjectListingPage> {
                 .toList() ??
             [],
         searchFields: objectData?.searchField ?? [],
+        initialFilterValues: {'app_id': appIdParam},
         onDetailNavigateFn: (itemId) async {
           await ObjectDetailRoute(
+            appId: appIdParam,
             objectType: objectTypeParam,
             objectId: itemId,
           ).push(context);

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -261,6 +261,7 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
     final objectTypeParam =
         GoRouterState.of(context).pathParameters['objectType']!;
     final objectIdParam = GoRouterState.of(context).pathParameters['objectId']!;
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectUpdatingWrapper(

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -7,7 +7,9 @@ import 'features/auth/pages/auth_page.dart';
 import 'features/auth/pages/azure_b2c_login_page.dart';
 import 'features/auth/pages/supabase_login_page.dart';
 import 'features/auth/pages/supabase_signup_page.dart';
-import 'features/home/pages/home_page.dart';
+import 'features/application/pages/application_listing_page.dart';
+import 'features/application/pages/app_home_page.dart';
+import 'features/application/pages/application_adding_page.dart';
 import 'features/notification/pages/powersync_debug_page.dart';
 import 'features/object/pages/external_object_detail_page.dart';
 import 'features/object/pages/external_object_listing_page.dart';
@@ -112,12 +114,36 @@ class Auth0LoginRoute extends GoRouteData {
 class HomeRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const HomePage();
+    return const ApplicationListingPage();
+  }
+}
+
+@TypedGoRoute<AppHomeRoute>(
+  path: '/app/:appId',
+)
+class AppHomeRoute extends GoRouteData {
+  const AppHomeRoute({required this.appId});
+
+  final String appId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return AppHomePage(appId: appId);
+  }
+}
+
+@TypedGoRoute<ApplicationAddingRoute>(
+  path: '/applications/add',
+)
+class ApplicationAddingRoute extends GoRouteData {
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const ApplicationAddingPage();
   }
 }
 
 @TypedGoRoute<ObjectListingRoute>(
-  path: '/internal/:objectType',
+  path: '/app/:appId/internal/:objectType',
   routes: [
     TypedGoRoute<ObjectAddingRoute>(
       path: 'add',
@@ -133,8 +159,9 @@ class HomeRoute extends GoRouteData {
   ],
 )
 class ObjectListingRoute extends GoRouteData {
-  ObjectListingRoute({required this.objectType});
+  ObjectListingRoute({required this.appId, required this.objectType});
 
+  final String appId;
   final String objectType;
 
   @override
@@ -144,8 +171,9 @@ class ObjectListingRoute extends GoRouteData {
 }
 
 class ObjectAddingRoute extends GoRouteData {
-  ObjectAddingRoute({required this.objectType});
+  ObjectAddingRoute({required this.appId, required this.objectType});
 
+  final String appId;
   final String objectType;
 
   @override
@@ -155,8 +183,9 @@ class ObjectAddingRoute extends GoRouteData {
 }
 
 class ObjectDetailRoute extends GoRouteData {
-  ObjectDetailRoute({required this.objectType, required this.objectId});
+  ObjectDetailRoute({required this.appId, required this.objectType, required this.objectId});
 
+  final String appId;
   final String objectType;
   final String objectId;
 
@@ -167,8 +196,9 @@ class ObjectDetailRoute extends GoRouteData {
 }
 
 class ObjectUpdatingRoute extends GoRouteData {
-  ObjectUpdatingRoute({required this.objectType, required this.objectId});
+  ObjectUpdatingRoute({required this.appId, required this.objectType, required this.objectId});
 
+  final String appId;
   final String objectType;
   final String objectId;
 

--- a/apps/apprm/lib/router.g.dart
+++ b/apps/apprm/lib/router.g.dart
@@ -9,6 +9,8 @@ part of 'router.dart';
 List<RouteBase> get $appRoutes => [
       $authPageRoute,
       $homeRoute,
+      $appHomeRoute,
+      $applicationAddingRoute,
       $objectListingRoute,
       $externalObjectListingRoute,
       $notificationRoute,
@@ -42,6 +44,52 @@ extension $AuthPageRouteExtension on AuthPageRoute {
 
   String get location => GoRouteData.$location(
         '/auth',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $appHomeRoute => GoRouteData.$route(
+      path: '/app/:appId',
+      factory: $AppHomeRouteExtension._fromState,
+    );
+
+extension $AppHomeRouteExtension on AppHomeRoute {
+  static AppHomeRoute _fromState(GoRouterState state) =>
+      AppHomeRoute(appId: state.pathParameters['appId']!);
+
+  String get location => GoRouteData.$location(
+        '/app/${Uri.encodeComponent(appId)}',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $applicationAddingRoute => GoRouteData.$route(
+      path: '/applications/add',
+      factory: $ApplicationAddingRouteExtension._fromState,
+    );
+
+extension $ApplicationAddingRouteExtension on ApplicationAddingRoute {
+  static ApplicationAddingRoute _fromState(GoRouterState state) =>
+      ApplicationAddingRoute();
+
+  String get location => GoRouteData.$location(
+        '/applications/add',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -163,7 +211,7 @@ extension $HomeRouteExtension on HomeRoute {
 }
 
 RouteBase get $objectListingRoute => GoRouteData.$route(
-      path: '/internal/:objectType',
+      path: '/app/:appId/internal/:objectType',
       factory: $ObjectListingRouteExtension._fromState,
       routes: [
         GoRouteData.$route(
@@ -186,11 +234,12 @@ RouteBase get $objectListingRoute => GoRouteData.$route(
 extension $ObjectListingRouteExtension on ObjectListingRoute {
   static ObjectListingRoute _fromState(GoRouterState state) =>
       ObjectListingRoute(
+        appId: state.pathParameters['appId']!,
         objectType: state.pathParameters['objectType']!,
       );
 
   String get location => GoRouteData.$location(
-        '/internal/${Uri.encodeComponent(objectType)}',
+        '/app/${Uri.encodeComponent(appId)}/internal/${Uri.encodeComponent(objectType)}',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -205,11 +254,12 @@ extension $ObjectListingRouteExtension on ObjectListingRoute {
 
 extension $ObjectAddingRouteExtension on ObjectAddingRoute {
   static ObjectAddingRoute _fromState(GoRouterState state) => ObjectAddingRoute(
+        appId: state.pathParameters['appId']!,
         objectType: state.pathParameters['objectType']!,
       );
 
   String get location => GoRouteData.$location(
-        '/internal/${Uri.encodeComponent(objectType)}/add',
+        '/app/${Uri.encodeComponent(appId)}/internal/${Uri.encodeComponent(objectType)}/add',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -224,12 +274,13 @@ extension $ObjectAddingRouteExtension on ObjectAddingRoute {
 
 extension $ObjectDetailRouteExtension on ObjectDetailRoute {
   static ObjectDetailRoute _fromState(GoRouterState state) => ObjectDetailRoute(
+        appId: state.pathParameters['appId']!,
         objectType: state.pathParameters['objectType']!,
         objectId: state.pathParameters['objectId']!,
       );
 
   String get location => GoRouteData.$location(
-        '/internal/${Uri.encodeComponent(objectType)}/${Uri.encodeComponent(objectId)}',
+        '/app/${Uri.encodeComponent(appId)}/internal/${Uri.encodeComponent(objectType)}/${Uri.encodeComponent(objectId)}',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -245,12 +296,13 @@ extension $ObjectDetailRouteExtension on ObjectDetailRoute {
 extension $ObjectUpdatingRouteExtension on ObjectUpdatingRoute {
   static ObjectUpdatingRoute _fromState(GoRouterState state) =>
       ObjectUpdatingRoute(
+        appId: state.pathParameters['appId']!,
         objectType: state.pathParameters['objectType']!,
         objectId: state.pathParameters['objectId']!,
       );
 
   String get location => GoRouteData.$location(
-        '/internal/${Uri.encodeComponent(objectType)}/${Uri.encodeComponent(objectId)}/update',
+        '/app/${Uri.encodeComponent(appId)}/internal/${Uri.encodeComponent(objectType)}/${Uri.encodeComponent(objectId)}/update',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- introduce `Application` model and mapper
- add app-level pages for listing, adding and navigating to application detail
- filter object listings by selected application
- allow passing extra data to object creation
- update router for nested application routes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684165dc6a2483218fa0cdf8f4d862eb