### PR TITLE
Enable completed field on requirements

### DIFF
--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -205,6 +205,14 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'completed',
+          label: 'Completed',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['false', 'true'],
+          asyncOptions: null,
+        ),
       ],
     ),
     'locations': (

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -44,6 +44,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'requirement', label: 'Requirement'),
         (key: 'description', label: 'Description'),
+        (key: 'completed', label: 'Completed'),
       ],
     ),
     'stories': (

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -123,6 +123,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'completed',
+          label: 'Completed',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['false', 'true'],
+          asyncOptions: null,
+        ),
       ],
     ),
     'stories': (


### PR DESCRIPTION
## Summary
- add completed field to requirement forms
- show completed status in requirement details

## Testing
- `flutter test apps/apprm/test/widget_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee189e3c8321b44e87c72953ef73