### PR TITLE
Add data fields feature

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/models/data_field.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/data_field.dart
@@ -1,0 +1,42 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'data_field.g.dart';
+
+abstract class DataField implements Built<DataField, DataFieldBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  @BuiltValueField(wireName: 'app_id')
+  String? get appId;
+
+  @BuiltValueField(wireName: 'data_object')
+  String? get dataObject;
+
+  String? get name;
+
+  String? get description;
+
+  String? get type;
+
+  @BuiltValueField(wireName: 'default_value')
+  String? get defaultValue;
+
+  DataField._();
+  factory DataField([void Function(DataFieldBuilder) updates]) = _$DataField;
+
+  static Serializer<DataField> get serializer => _$dataFieldSerializer;
+
+  factory DataField.fromJson(Map<String, dynamic> json) =>
+      serializers.deserializeWith<DataField>(serializer, json)!;
+
+  Map<String, dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/data_field.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/data_field.g.dart
@@ -1,0 +1,316 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'data_field.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<DataField> _$dataFieldSerializer = new _$DataFieldSerializer();
+
+class _$DataFieldSerializer implements StructuredSerializer<DataField> {
+  @override
+  final Iterable<Type> types = const [DataField, _$DataField];
+  @override
+  final String wireName = 'DataField';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, DataField object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.appId;
+    if (value != null) {
+      result
+        ..add('app_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.dataObject;
+    if (value != null) {
+      result
+        ..add('data_object')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.name;
+    if (value != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.type;
+    if (value != null) {
+      result
+        ..add('type')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.defaultValue;
+    if (value != null) {
+      result
+        ..add('default_value')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  DataField deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new DataFieldBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'app_id':
+          result.appId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'data_object':
+          result.dataObject = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'type':
+          result.type = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'default_value':
+          result.defaultValue = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$DataField extends DataField {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? appId;
+  @override
+  final String? dataObject;
+  @override
+  final String? name;
+  @override
+  final String? description;
+  @override
+  final String? type;
+  @override
+  final String? defaultValue;
+
+  factory _$DataField([void Function(DataFieldBuilder)? updates]) =>
+      (new DataFieldBuilder()..update(updates))._build();
+
+  _$DataField._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.appId,
+      this.dataObject,
+      this.name,
+      this.description,
+      this.type,
+      this.defaultValue})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'DataField', 'id');
+    BuiltValueNullFieldError.checkNotNull(createdAt, r'DataField', 'createdAt');
+  }
+
+  @override
+  DataField rebuild(void Function(DataFieldBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  DataFieldBuilder toBuilder() => new DataFieldBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is DataField &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        appId == other.appId &&
+        dataObject == other.dataObject &&
+        name == other.name &&
+        description == other.description &&
+        type == other.type &&
+        defaultValue == other.defaultValue;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, appId.hashCode);
+    _$hash = $jc(_$hash, dataObject.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, type.hashCode);
+    _$hash = $jc(_$hash, defaultValue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'DataField')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('appId', appId)
+          ..add('dataObject', dataObject)
+          ..add('name', name)
+          ..add('description', description)
+          ..add('type', type)
+          ..add('defaultValue', defaultValue))
+        .toString();
+  }
+}
+
+class DataFieldBuilder implements Builder<DataField, DataFieldBuilder> {
+  _$DataField? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _appId;
+  String? get appId => _$this._appId;
+  set appId(String? appId) => _$this._appId = appId;
+
+  String? _dataObject;
+  String? get dataObject => _$this._dataObject;
+  set dataObject(String? dataObject) => _$this._dataObject = dataObject;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  String? _type;
+  String? get type => _$this._type;
+  set type(String? type) => _$this._type = type;
+
+  String? _defaultValue;
+  String? get defaultValue => _$this._defaultValue;
+  set defaultValue(String? defaultValue) => _$this._defaultValue = defaultValue;
+
+  DataFieldBuilder();
+
+  DataFieldBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _appId = $v.appId;
+      _dataObject = $v.dataObject;
+      _name = $v.name;
+      _description = $v.description;
+      _type = $v.type;
+      _defaultValue = $v.defaultValue;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(DataField other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$DataField;
+  }
+
+  @override
+  void update(void Function(DataFieldBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  DataField build() => _build();
+
+  _$DataField _build() {
+    final _$result = _$v ??
+        new _$DataField._(
+            id: BuiltValueNullFieldError.checkNotNull(id, r'DataField', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'DataField', 'createdAt'),
+            updatedAt: updatedAt,
+            appId: appId,
+            dataObject: dataObject,
+            name: name,
+            description: description,
+            type: type,
+            defaultValue: defaultValue);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
@@ -10,6 +10,7 @@ import 'location.dart';
 import 'person.dart';
 import 'sap_user.dart';
 import 'data_object.dart';
+import 'data_field.dart';
 import 'screen.dart';
 import 'story.dart';
 import 'user_story.dart';
@@ -27,6 +28,7 @@ const List<Type> _registeredTypes = [
   SapUser,
   Requirement,
   DataObject,
+  DataField,
   Screen,
   Story,
   UserStory,

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
@@ -9,6 +9,7 @@ part of 'serializers.dart';
 Serializers _$serializers = (new Serializers().toBuilder()
       ..add(AdpUser.serializer)
       ..add(Car.serializer)
+      ..add(DataField.serializer)
       ..add(DataObject.serializer)
       ..add(Location.serializer)
       ..add(Person.serializer)

--- a/apps/apprm/lib/features/common_object/widgets/detail/data_field_list.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/data_field_list.dart
@@ -1,0 +1,118 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../../constants/color.dart';
+import '../../foundation/object_repository.dart';
+import '../../foundation/use_cases/get_object_list_usecase.dart';
+
+class DataFieldList extends ConsumerStatefulWidget {
+  const DataFieldList({super.key, required this.dataObjectId});
+
+  final String dataObjectId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _DataFieldListState();
+}
+
+class _DataFieldListState extends ConsumerState<DataFieldList> {
+  void onRefresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['data_fields', 'list', widget.dataObjectId]
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Data fields',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'data_fields',
+                  'list',
+                  widget.dataObjectId,
+                ],
+                queryFn: () async {
+                  return await GetObjectListUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetObjectListUseCaseParams(
+                      objectType: 'data_fields',
+                      sortValues: const {},
+                      filterValues: {'data_object': widget.dataObjectId},
+                      searchFields: const ['name'],
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: const Duration(seconds: 1),
+                  refetchDuration: const Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (state.data?.isEmpty ?? true)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...state.data!.map(
+                      (e) => Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 8,
+                          horizontal: 12,
+                        ),
+                        child: Text(
+                          '${e['name'] ?? '--'} (${e['type'] ?? ''})',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: () async {
+                        await context.push(
+                          '/app/$appIdParam/internal/data_fields/add?data_object=${widget.dataObjectId}',
+                        );
+                        onRefresh();
+                      },
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -1,4 +1,5 @@
 import 'package:apprm/features/common_object/widgets/detail/external_system_connected.dart';
+import 'package:apprm/features/common_object/widgets/detail/data_field_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -54,6 +55,10 @@ class ObjectDetailCard extends ConsumerWidget {
               ExternalSystemConnected(
                 objectType: objectType,
                 objectId: objectId,
+              ),
+            if (objectType == 'data_objects')
+              DataFieldList(
+                dataObjectId: objectId,
               ),
           ],
         ),

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -186,6 +186,43 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         ),
       ],
     ),
+    'data_fields': (
+      label: 'data_field',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'type',
+          label: 'Type',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'default_value',
+          label: 'Default value',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'requirements': (
       label: 'requirement',
       inputFields: [
@@ -267,6 +304,7 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
     final objectTypeParam =
         GoRouterState.of(context).pathParameters['objectType']!;
     final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+    final dataObjectParam = GoRouterState.of(context).queryParameters['data_object'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectAddingWrapper(
@@ -283,7 +321,10 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
                   ))
               .toList() ??
           [],
-      extraData: {'app_id': appIdParam},
+      extraData: {
+        'app_id': appIdParam,
+        if (dataObjectParam != null) 'data_object': dataObjectParam,
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- create DataField model and serializer registration
- enable adding DataFields via ObjectAddingPage
- display DataFieldList on DataObject detail page

## Testing
- `flutter test` *(fails: Multiple exceptions in widget tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842ae22dc3c8321b81615046828ed31