### PR TITLE
Add data field detail editing

### DIFF
--- a/apps/apprm/lib/features/common_object/mappers/data_field_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/data_field_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/data_field.dart';
+
+class DataFieldToObjectItemMapper {
+  static ObjectItem fromModel(DataField item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.name ?? '',
+      subTitle: item.type ?? '',
+      sortFields: [
+        (key: 'name', label: 'Name'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(DataField.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/data_field_list.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/data_field_list.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:apprm/router.dart';
 
 import '../../../../constants/color.dart';
 import '../../foundation/object_repository.dart';
@@ -77,16 +78,28 @@ class _DataFieldListState extends ConsumerState<DataFieldList> {
                     )
                   else
                     ...state.data!.map(
-                      (e) => Padding(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: 8,
-                          horizontal: 12,
-                        ),
-                        child: Text(
-                          '${e['name'] ?? '--'} (${e['type'] ?? ''})',
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w500,
+                      (e) => InkWell(
+                        onTap: () async {
+                          final result = await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'data_fields',
+                            objectId: e['id'],
+                          ).push(context);
+                          if (result == true) {
+                            onRefresh();
+                          }
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            '${e['name'] ?? '--'} (${e['type'] ?? ''})',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
                           ),
                         ),
                       ),

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -11,6 +11,7 @@ import '../../common_object/mappers/data_object_mapper.dart';
 import '../../common_object/mappers/requirement_mapper.dart';
 import '../../common_object/mappers/story_mapper.dart';
 import '../../common_object/mappers/user_story_mapper.dart';
+import '../../common_object/mappers/data_field_mapper.dart';
 import '../../common_object/widgets/detail/object_detail_wrapper.dart';
 
 class ObjectDetailPage extends StatefulWidget {
@@ -73,6 +74,15 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),
+      ],
+    ),
+    'data_fields': (
+      dataMapperFn: DataFieldToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+        (key: 'type', label: 'Type'),
+        (key: 'default_value', label: 'Default value'),
       ],
     ),
     'locations': (

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -217,6 +217,43 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'data_fields': (
+      label: 'data_field',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'type',
+          label: 'Type',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'default_value',
+          label: 'Default value',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'locations': (
       label: 'location',
       inputFields: [


### PR DESCRIPTION
## Summary
- add `DataFieldToObjectItemMapper`
- display data field info on detail page
- support editing data fields
- link data field list entries to their detail pages

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e69d7de883219db4798640ab7530