### PR TITLE
Enable screen photos with offline support

### DIFF
--- a/apps/apprm/lib/attachments/queue.dart
+++ b/apps/apprm/lib/attachments/queue.dart
@@ -68,9 +68,9 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
 
   @override
   StreamSubscription<void> watchIds({String fileExtension = 'jpg'}) {
-    log.info('Watching photos in demo...');
+    log.info('Watching screen photos...');
     return db.watch('''
-      SELECT photo_id FROM demo
+      SELECT photo_id FROM screen_photos
       WHERE photo_id IS NOT NULL
     ''').map((results) {
       return results.map((row) => row['photo_id'] as String).toList();

--- a/apps/apprm/lib/configs/supabase.dart
+++ b/apps/apprm/lib/configs/supabase.dart
@@ -3,5 +3,5 @@ class SupabaseConfig {
   static const String anonKey =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Ind6cnFlc2xxZXlzZGJzcGZxYmZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDA1MTcxMjksImV4cCI6MjA1NjA5MzEyOX0.rGzlK4-sAHgGA4jsXkEh1m7mEF9hOCZSOx4isMZ4G4U';
 
-  static const String storageBucket = '';
+  static const String storageBucket = 'screens';
 }

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -1,5 +1,6 @@
 import 'package:apprm/features/common_object/widgets/detail/external_system_connected.dart';
 import 'package:apprm/features/common_object/widgets/detail/data_field_list.dart';
+import 'package:apprm/features/screens/widgets/screen_photo_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,12 +10,14 @@ class ObjectDetailCard extends ConsumerWidget {
     super.key,
     required this.objectType,
     required this.objectId,
+    required this.appId,
     required this.displayFields,
     this.objectItem,
   });
 
   final String objectType;
   final String objectId;
+  final String appId;
   final List<DisplayField> displayFields;
   final Map<String, dynamic>? objectItem;
 
@@ -59,6 +62,11 @@ class ObjectDetailCard extends ConsumerWidget {
             if (objectType == 'data_objects')
               DataFieldList(
                 dataObjectId: objectId,
+              ),
+            if (objectType == 'screens')
+              ScreenPhotoList(
+                appId: appId,
+                screenId: objectId,
               ),
           ],
         ),

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_wrapper.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_wrapper.dart
@@ -22,6 +22,7 @@ class ObjectDetailWrapper extends ConsumerStatefulWidget {
     super.key,
     required this.objectType,
     required this.objectId,
+    required this.appId,
     required this.mapperFn,
     required this.displayFields,
     required this.onEditingNavigateFn,
@@ -29,6 +30,7 @@ class ObjectDetailWrapper extends ConsumerStatefulWidget {
 
   final String objectType;
   final String objectId;
+  final String appId;
   final ObjectItem Function(Map<String, dynamic>) mapperFn;
   final List<DisplayField> displayFields;
   final VoidCallback onEditingNavigateFn;
@@ -190,6 +192,7 @@ class _ObjectDetailWrapperState extends ConsumerState<ObjectDetailWrapper> {
               child: ObjectDetailCard(
                 objectType: widget.objectType,
                 objectId: widget.objectId,
+                appId: widget.appId,
                 displayFields: widget.displayFields,
                 objectItem: state.data,
               ),

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -107,6 +107,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
     return ObjectDetailWrapper(
       objectType: objectTypeParam,
       objectId: objectIdParam,
+      appId: appIdParam!,
       mapperFn: objectData?.dataMapperFn ?? (e) => ObjectItem.fromJson(e),
       displayFields: objectData?.displayFields
               .map((e) => (key: e.key, label: e.label))

--- a/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
@@ -1,0 +1,166 @@
+import 'dart:io';
+
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../attachments/queue.dart';
+import '../../../constants/color.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/create_object_usecase.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+
+class ScreenPhotoList extends ConsumerStatefulWidget {
+  const ScreenPhotoList({super.key, required this.appId, required this.screenId});
+
+  final String appId;
+  final String screenId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ScreenPhotoListState();
+}
+
+class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
+  final ImagePicker _picker = ImagePicker();
+
+  final _createMutation = Mutation<void, CreateObjectUseCaseParams>(
+    queryFn: (params) => CreateObjectUseCase(
+      objectRepository: ObjectRepository(),
+    ).execute(params),
+  );
+
+  void _refresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['screen_photos', 'list', widget.screenId]
+    ]);
+  }
+
+  Future<void> _addPhoto() async {
+    final XFile? file = await _picker.pickImage(source: ImageSource.gallery);
+    if (file == null) return;
+
+    final bytes = await file.readAsBytes();
+    final photoId = const Uuid().v4();
+    final filename = '$photoId.jpg';
+    final filePath = attachmentQueue.getLocalFilePathSuffix(filename);
+    final localUri = await attachmentQueue.getLocalUri(filePath);
+
+    await attachmentQueue.localStorage.copyFile(file.path, localUri);
+    await attachmentQueue.saveFile(photoId, bytes.length);
+
+    await _createMutation.mutate(
+      CreateObjectUseCaseParams(
+        objectType: 'screen_photos',
+        data: {
+          'app_id': widget.appId,
+          'screen_id': widget.screenId,
+          'name': file.name,
+          'photo_id': photoId,
+        },
+      ),
+    );
+
+    _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Photos',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'screen_photos',
+                  'list',
+                  widget.screenId,
+                ],
+                queryFn: () async {
+                  return await GetObjectListUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetObjectListUseCaseParams(
+                      objectType: 'screen_photos',
+                      sortValues: const {},
+                      filterValues: {'screen_id': widget.screenId},
+                      searchFields: const ['name'],
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: const Duration(seconds: 1),
+                  refetchDuration: const Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              final list = state.data ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (list.isEmpty)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: list.map((e) {
+                        return FutureBuilder<String>(
+                          future: attachmentQueue.getLocalUri(
+                              attachmentQueue.getLocalFilePathSuffix(
+                                  '${e['photo_id']}.jpg')),
+                          builder: (context, snapshot) {
+                            if (!snapshot.hasData) {
+                              return const SizedBox(
+                                width: 80,
+                                height: 80,
+                                child: Center(child: CircularProgressIndicator()),
+                              );
+                            }
+                            final file = File(snapshot.data!);
+                            return Image.file(
+                              file,
+                              width: 80,
+                              height: 80,
+                              fit: BoxFit.cover,
+                            );
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: _addPhoto,
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/pubspec.lock
+++ b/apps/apprm/pubspec.lock
@@ -253,6 +253,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -333,6 +341,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "54cbbd957e1156d29548c7d9b9ec0c0ebb6de0a90452198683a7d23aed617a33"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+2"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4+2"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: a3994c26f10378a039faa11de174d7b78eb8f79e4dd0af2a451410c1a5c3f66b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "320fcfb6f33caa90f0b58380489fc5ac05d99ee94b61aa96ec2bff0ba81d3c2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+4"
   fixnum:
     dependency: transitive
     description:
@@ -391,6 +431,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "1c2b787f99bdca1f3718543f81d38aa1b124817dfeb9fb196201bea85b6134bf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.26"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -521,6 +569,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "021834d9c0c3de46bf0fe40341fa07168407f694d9b2bb18d532dc1261867f7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+21"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "717eb042ab08c40767684327be06a5d8dbb341fe791d514e4b92c7bbe1b7bb83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.6"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: "05da758e67bc7839e886b3959848aa6b44ff123ab4b28f67891008afe8ef9100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.12+2"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "34a65f6740df08bbbeb0a1abd8e6d32107941fd4868f67a507b25601651022c9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "1b90ebbd9dcf98fb6c1d01427e49a55bd96b5d67b8c67cf955d60a5de74207c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1+1"
   intl:
     dependency: "direct main"
     description:
@@ -1191,13 +1303,13 @@ packages:
     source: hosted
     version: "3.1.2"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
-      sha256: "83d37c7ad7aaf9aa8e275490669535c8080377cfa7a7004c24dfac53afffaa90"
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.2"
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -1312,4 +1424,4 @@ packages:
     version: "2.0.2"
 sdks:
   dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.24.0"

--- a/apps/apprm/pubspec.yaml
+++ b/apps/apprm/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   sqlite_async: ^0.8.1
   logging: ^1.2.0
   image: ^4.2.0
+  image_picker: ^1.1.2
+  uuid: ^4.5.1
   phosphor_flutter: ^2.1.0
   modal_bottom_sheet: ^3.0.0
   flutter_riverpod: ^2.5.1


### PR DESCRIPTION
## Summary
- set storage bucket for Supabase
- watch `screen_photos` in attachment queue
- allow photo uploads on screen detail
- display uploaded photos in screen detail
- add `image_picker` and `uuid` dependencies

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_684427e3b05c8321be099d23614736e0