### PR TITLE
Fix attachment file paths and enhance debug info

### DIFF
--- a/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
@@ -45,8 +45,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
     final bytes = await file.readAsBytes();
     final photoId = const Uuid().v4();
     final filename = '$photoId.jpg';
-    final filePath = attachmentQueue.getLocalFilePathSuffix(filename);
-    final localUri = await attachmentQueue.getLocalUri(filePath);
+    final localUri = await attachmentQueue.getLocalUri(filename);
 
     // Ensure the directory exists
     final destDir = Directory(localUri).parent;
@@ -128,9 +127,8 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
                       runSpacing: 8,
                       children: list.map((e) {
                         return FutureBuilder<String>(
-                          future: attachmentQueue.getLocalUri(
-                              attachmentQueue.getLocalFilePathSuffix(
-                                  '${e['photo_id']}.jpg')),
+                          future: attachmentQueue
+                              .getLocalUri('${e['photo_id']}.jpg'),
                           builder: (context, snapshot) {
                             if (!snapshot.hasData) {
                               return const SizedBox(


### PR DESCRIPTION
## Summary
- fix local file path when saving screen photos so uploads work
- adjust image loading path accordingly
- show attachment queue status on debug page for easier diagnostics

## Testing
- `dart format apps/apprm/lib/features/notification/pages/powersync_debug_page.dart apps/apprm/lib/features/screens/widgets/screen_photo_list.dart` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845a9625ea883219fcce70da22a97ae