### PR TITLE
Add screen functions section

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -209,6 +209,21 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'screen_functions',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('app_id'),
+        Column.text('screen_id'),
+        Column.text('name'),
+        Column.text('description'),
+      ],
+      indexes: [
+        Index('screen_functions_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'user_stories',
       [
         Column.text('id'),

--- a/apps/apprm/lib/features/common_object/foundation/models/screen_function.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/screen_function.dart
@@ -1,0 +1,37 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'screen_function.g.dart';
+
+abstract class ScreenFunction implements Built<ScreenFunction, ScreenFunctionBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  @BuiltValueField(wireName: 'app_id')
+  String? get appId;
+
+  @BuiltValueField(wireName: 'screen_id')
+  String? get screenId;
+
+  String? get name;
+
+  String? get description;
+
+  ScreenFunction._();
+  factory ScreenFunction([void Function(ScreenFunctionBuilder) updates]) = _$ScreenFunction;
+
+  static Serializer<ScreenFunction> get serializer => _$screenFunctionSerializer;
+
+  factory ScreenFunction.fromJson(Map<String, dynamic> json) =>
+      serializers.deserializeWith<ScreenFunction>(serializer, json)!;
+
+  Map<String, dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/screen_function.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/screen_function.g.dart
@@ -1,0 +1,277 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'screen_function.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<ScreenFunction> _$screenFunctionSerializer =
+    new _$ScreenFunctionSerializer();
+
+class _$ScreenFunctionSerializer
+    implements StructuredSerializer<ScreenFunction> {
+  @override
+  final Iterable<Type> types = const [ScreenFunction, _$ScreenFunction];
+  @override
+  final String wireName = 'ScreenFunction';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, ScreenFunction object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.appId;
+    if (value != null) {
+      result
+        ..add('app_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.screenId;
+    if (value != null) {
+      result
+        ..add('screen_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.name;
+    if (value != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  ScreenFunction deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new ScreenFunctionBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'app_id':
+          result.appId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'screen_id':
+          result.screenId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$ScreenFunction extends ScreenFunction {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? appId;
+  @override
+  final String? screenId;
+  @override
+  final String? name;
+  @override
+  final String? description;
+
+  factory _$ScreenFunction([void Function(ScreenFunctionBuilder)? updates]) =>
+      (new ScreenFunctionBuilder()..update(updates))._build();
+
+  _$ScreenFunction._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.appId,
+      this.screenId,
+      this.name,
+      this.description})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'ScreenFunction', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        createdAt, r'ScreenFunction', 'createdAt');
+  }
+
+  @override
+  ScreenFunction rebuild(void Function(ScreenFunctionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  ScreenFunctionBuilder toBuilder() =>
+      new ScreenFunctionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is ScreenFunction &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        appId == other.appId &&
+        screenId == other.screenId &&
+        name == other.name &&
+        description == other.description;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, appId.hashCode);
+    _$hash = $jc(_$hash, screenId.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'ScreenFunction')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('appId', appId)
+          ..add('screenId', screenId)
+          ..add('name', name)
+          ..add('description', description))
+        .toString();
+  }
+}
+
+class ScreenFunctionBuilder
+    implements Builder<ScreenFunction, ScreenFunctionBuilder> {
+  _$ScreenFunction? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _appId;
+  String? get appId => _$this._appId;
+  set appId(String? appId) => _$this._appId = appId;
+
+  String? _screenId;
+  String? get screenId => _$this._screenId;
+  set screenId(String? screenId) => _$this._screenId = screenId;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  ScreenFunctionBuilder();
+
+  ScreenFunctionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _appId = $v.appId;
+      _screenId = $v.screenId;
+      _name = $v.name;
+      _description = $v.description;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(ScreenFunction other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$ScreenFunction;
+  }
+
+  @override
+  void update(void Function(ScreenFunctionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  ScreenFunction build() => _build();
+
+  _$ScreenFunction _build() {
+    final _$result = _$v ??
+        new _$ScreenFunction._(
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, r'ScreenFunction', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'ScreenFunction', 'createdAt'),
+            updatedAt: updatedAt,
+            appId: appId,
+            screenId: screenId,
+            name: name,
+            description: description);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
@@ -12,6 +12,7 @@ import 'sap_user.dart';
 import 'data_object.dart';
 import 'data_field.dart';
 import 'screen.dart';
+import 'screen_function.dart';
 import 'story.dart';
 import 'user_story.dart';
 import 'serialize_plugins/custom_8601_date_time_plugin.dart';
@@ -30,6 +31,7 @@ const List<Type> _registeredTypes = [
   DataObject,
   DataField,
   Screen,
+  ScreenFunction,
   Story,
   UserStory,
 ];

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
@@ -16,6 +16,7 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(Requirement.serializer)
       ..add(SapUser.serializer)
       ..add(Screen.serializer)
+      ..add(ScreenFunction.serializer)
       ..add(Story.serializer)
       ..add(UserStory.serializer))
     .build();

--- a/apps/apprm/lib/features/common_object/mappers/screen_function_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/screen_function_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/screen_function.dart';
+
+class ScreenFunctionToObjectItemMapper {
+  static ObjectItem fromModel(ScreenFunction item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.name ?? '',
+      subTitle: item.description ?? '',
+      sortFields: [
+        (key: 'name', label: 'Name'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(ScreenFunction.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -1,6 +1,7 @@
 import 'package:apprm/features/common_object/widgets/detail/external_system_connected.dart';
 import 'package:apprm/features/common_object/widgets/detail/data_field_list.dart';
 import 'package:apprm/features/screens/widgets/screen_photo_list.dart';
+import 'package:apprm/features/screens/widgets/screen_function_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -63,11 +64,15 @@ class ObjectDetailCard extends ConsumerWidget {
               DataFieldList(
                 dataObjectId: objectId,
               ),
-            if (objectType == 'screens')
+            if (objectType == 'screens') ...[
+              ScreenFunctionList(
+                screenId: objectId,
+              ),
               ScreenPhotoList(
                 appId: appId,
                 screenId: objectId,
               ),
+            ],
           ],
         ),
       ),

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -144,6 +144,27 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         ),
       ],
     ),
+    'screen_functions': (
+      label: 'function',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'user_stories': (
       label: 'user_story',
       inputFields: [
@@ -305,6 +326,7 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         GoRouterState.of(context).pathParameters['objectType']!;
     final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
     final dataObjectParam = GoRouterState.of(context).queryParameters['data_object'];
+    final screenIdParam = GoRouterState.of(context).queryParameters['screen_id'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectAddingWrapper(
@@ -324,6 +346,7 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
       extraData: {
         'app_id': appIdParam,
         if (dataObjectParam != null) 'data_object': dataObjectParam,
+        if (screenIdParam != null) 'screen_id': screenIdParam,
       },
     );
   }

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -12,6 +12,7 @@ import '../../common_object/mappers/requirement_mapper.dart';
 import '../../common_object/mappers/story_mapper.dart';
 import '../../common_object/mappers/user_story_mapper.dart';
 import '../../common_object/mappers/data_field_mapper.dart';
+import '../../common_object/mappers/screen_function_mapper.dart';
 import '../../common_object/widgets/detail/object_detail_wrapper.dart';
 
 class ObjectDetailPage extends StatefulWidget {
@@ -57,6 +58,13 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
     ),
     'screens': (
       dataMapperFn: ScreenToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+      ],
+    ),
+    'screen_functions': (
+      dataMapperFn: ScreenFunctionToObjectItemMapper.fromJson,
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -175,6 +175,27 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'screen_functions': (
+      label: 'function',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'screen_photos': (
       label: 'photo',
       inputFields: [

--- a/apps/apprm/lib/features/screens/widgets/screen_function_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/screen_function_list.dart
@@ -1,0 +1,131 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:apprm/router.dart';
+
+import '../../../constants/color.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+
+class ScreenFunctionList extends ConsumerStatefulWidget {
+  const ScreenFunctionList({super.key, required this.screenId});
+
+  final String screenId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ScreenFunctionListState();
+}
+
+class _ScreenFunctionListState extends ConsumerState<ScreenFunctionList> {
+  void onRefresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['screen_functions', 'list', widget.screenId]
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Functions',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'screen_functions',
+                  'list',
+                  widget.screenId,
+                ],
+                queryFn: () async {
+                  return await GetObjectListUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetObjectListUseCaseParams(
+                      objectType: 'screen_functions',
+                      sortValues: const {},
+                      filterValues: {'screen_id': widget.screenId},
+                      searchFields: const ['name'],
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: const Duration(seconds: 1),
+                  refetchDuration: const Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (state.data?.isEmpty ?? true)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...state.data!.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final result = await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'screen_functions',
+                            objectId: e['id'],
+                          ).push(context);
+                          if (result == true) {
+                            onRefresh();
+                          }
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['name'] ?? '--',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: () async {
+                        await context.push(
+                          '/app/$appIdParam/internal/screen_functions/add?screen_id=${widget.screenId}',
+                        );
+                        onRefresh();
+                      },
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- model new `screen_functions` table in local schema
- generate ScreenFunction built_value model and mapper
- show functions on screen detail view with add/delete flow
- support screen function CRUD pages
- register new model in serializers

## Testing
- `flutter pub get`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter test` *(fails: Supabase instance not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684604bd8a74832189cc064c8ba56aed