### PR TITLE
Add work log feature

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -252,6 +252,20 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'work_logs',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('app_id'),
+        Column.text('amount'),
+        Column.text('description'),
+      ],
+      indexes: [
+        Index('work_logs_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'applications',
       [
         Column.text('id'),

--- a/apps/apprm/lib/features/application/pages/app_home_page.dart
+++ b/apps/apprm/lib/features/application/pages/app_home_page.dart
@@ -40,6 +40,11 @@ class _AppHomePageState extends State<AppHomePage> {
         icon: PhosphorIconsFill.books,
         title: 'User Stories',
         route: '/app/${widget.appId}/internal/user_stories'
+      ),
+      (
+        icon: PhosphorIconsFill.clock,
+        title: 'Work Log',
+        route: '/app/${widget.appId}/internal/work_logs'
       )
     ];
 

--- a/apps/apprm/lib/features/common_object/mappers/work_log_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/work_log_mapper.dart
@@ -1,0 +1,16 @@
+import '../entities/object_item.dart';
+
+class WorkLogToObjectItemMapper {
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return ObjectItem(
+      id: json['id'] as String,
+      title: (json['amount'] ?? '').toString(),
+      subTitle: json['description'] ?? '',
+      sortFields: [
+        (key: 'amount', label: 'Amount'),
+      ],
+      raw: json,
+      rawJson: json,
+    );
+  }
+}

--- a/apps/apprm/lib/features/home/pages/home_page.dart
+++ b/apps/apprm/lib/features/home/pages/home_page.dart
@@ -25,11 +25,20 @@ class _HomePageState extends State<HomePage> {
       title: 'Data Model',
       route: '/internal/data_objects'
     ),
-    (icon: PhosphorIconsFill.chalkboard, title: 'Screens', route: '/internal/screens'),
+    (
+      icon: PhosphorIconsFill.chalkboard,
+      title: 'Screens',
+      route: '/internal/screens'
+    ),
     (
       icon: PhosphorIconsFill.books,
       title: 'User Stories',
       route: '/internal/user_stories'
+    ),
+    (
+      icon: PhosphorIconsFill.clock,
+      title: 'Work Log',
+      route: '/internal/work_logs'
     )
   ];
 

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -186,6 +186,27 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         ),
       ],
     ),
+    'work_logs': (
+      label: 'work log',
+      inputFields: [
+        (
+          key: 'amount',
+          label: 'Amount',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['0.5', '1', '1.5', '2'],
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'data_objects': (
       label: 'data_object',
       inputFields: [
@@ -325,8 +346,10 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
     final objectTypeParam =
         GoRouterState.of(context).pathParameters['objectType']!;
     final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
-    final dataObjectParam = GoRouterState.of(context).queryParameters['data_object'];
-    final screenIdParam = GoRouterState.of(context).queryParameters['screen_id'];
+    final dataObjectParam =
+        GoRouterState.of(context).queryParameters['data_object'];
+    final screenIdParam =
+        GoRouterState.of(context).queryParameters['screen_id'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectAddingWrapper(

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -13,6 +13,7 @@ import '../../common_object/mappers/story_mapper.dart';
 import '../../common_object/mappers/user_story_mapper.dart';
 import '../../common_object/mappers/data_field_mapper.dart';
 import '../../common_object/mappers/screen_function_mapper.dart';
+import '../../common_object/mappers/work_log_mapper.dart';
 import '../../common_object/widgets/detail/object_detail_wrapper.dart';
 
 class ObjectDetailPage extends StatefulWidget {
@@ -74,6 +75,13 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       dataMapperFn: UserStoryToObjectItemMapper.fromJson,
       displayFields: [
         (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+      ],
+    ),
+    'work_logs': (
+      dataMapperFn: WorkLogToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'amount', label: 'Amount'),
         (key: 'description', label: 'Description'),
       ],
     ),

--- a/apps/apprm/lib/features/object/pages/object_listing_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_listing_page.dart
@@ -14,6 +14,7 @@ import '../../common_object/mappers/story_mapper.dart';
 import '../../common_object/mappers/user_story_mapper.dart';
 import '../../common_object/mappers/data_object_mapper.dart';
 import '../../common_object/mappers/requirement_mapper.dart';
+import '../../common_object/mappers/work_log_mapper.dart';
 import '../../common_object/widgets/listing/object_list_wrapper.dart';
 import '../widgets/generic_item_card.dart';
 import '../widgets/generic_list_empty.dart';
@@ -24,6 +25,7 @@ import '../widgets/location_item_card.dart';
 import '../widgets/location_list_empty.dart';
 import '../widgets/people_empty.dart';
 import '../widgets/person_item_card.dart';
+import '../../../typedefs/sort_field.dart';
 
 class ObjectListingPage extends StatefulWidget {
   const ObjectListingPage({super.key});
@@ -103,6 +105,17 @@ class _ObjectListingPageState extends State<ObjectListingPage> {
         (key: 'name', label: 'Name'),
       ],
       searchField: ['name']
+    ),
+    'work_logs': (
+      title: 'Work Log',
+      objectItemCard: (item) => GenericItemCard(item: item),
+      objectEmptyWidget: () => const GenericListEmpty(),
+      dataMapperFn: WorkLogToObjectItemMapper.fromJson,
+      sortFields: [
+        (key: 'created_at', label: 'Date'),
+      ],
+      filterFields: [],
+      searchField: ['description']
     ),
     'stories': (
       title: 'Stories',
@@ -206,11 +219,17 @@ class _ObjectListingPageState extends State<ObjectListingPage> {
             ? null
             : () => objectData.objectEmptyWidget.call(),
         sortFields: objectData?.sortFields
-                .map((e) => (key: e.key, label: e.label, value: null))
+                .map<({String key, String label, SortValueEnum? value})>((e) =>
+                    (
+                      key: e.key as String,
+                      label: e.label as String,
+                      value: null
+                    ))
                 .toList() ??
             [],
         filterFields: objectData?.filterFields
-                .map((e) => (key: e.key, label: e.label))
+                .map<({String key, String label})>(
+                    (e) => (key: e.key as String, label: e.label as String))
                 .toList() ??
             [],
         searchFields: objectData?.searchField ?? [],

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -238,6 +238,27 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'work_logs': (
+      label: 'work log',
+      inputFields: [
+        (
+          key: 'amount',
+          label: 'Amount',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['0.5', '1', '1.5', '2'],
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'data_objects': (
       label: 'data_object',
       inputFields: [


### PR DESCRIPTION
## Summary
- add `WorkLogToObjectItemMapper`
- extend listing, detail, adding and updating pages to support work logs
- update database schema with `work_logs` table
- show work log option in application and home pages

## Testing
- `dart analyze`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_684731e982dc8321aa9bd152be7d076c