### PR TITLE
Add main home menu and global work log listing

### DIFF
--- a/apps/apprm/lib/features/application/pages/application_home_page.dart
+++ b/apps/apprm/lib/features/application/pages/application_home_page.dart
@@ -6,16 +6,16 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
-class AppHomePage extends StatefulWidget {
-  const AppHomePage({super.key, required this.appId});
+class ApplicationHomePage extends StatefulWidget {
+  const ApplicationHomePage({super.key, required this.appId});
 
   final String appId;
 
   @override
-  State<AppHomePage> createState() => _AppHomePageState();
+  State<ApplicationHomePage> createState() => _ApplicationHomePageState();
 }
 
-class _AppHomePageState extends State<AppHomePage> {
+class _ApplicationHomePageState extends State<ApplicationHomePage> {
   late final List<({IconData icon, String title, String route})> objectListData;
 
   @override

--- a/apps/apprm/lib/features/application/pages/application_listing_page.dart
+++ b/apps/apprm/lib/features/application/pages/application_listing_page.dart
@@ -58,7 +58,7 @@ class _ApplicationListingPageState extends State<ApplicationListingPage> {
         filterFields: const [],
         searchFields: const ['name'],
         onDetailNavigateFn: (id) {
-          AppHomeRoute(appId: id).push(context);
+          ApplicationHomeRoute(appId: id).push(context);
         },
       ),
     );

--- a/apps/apprm/lib/features/home/pages/home_page.dart
+++ b/apps/apprm/lib/features/home/pages/home_page.dart
@@ -16,29 +16,14 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   final objectListData = [
     (
-      icon: PhosphorIconsFill.asterisk,
-      title: 'Requirements',
-      route: '/internal/requirements'
-    ),
-    (
-      icon: PhosphorIconsFill.treeStructure,
-      title: 'Data Model',
-      route: '/internal/data_objects'
-    ),
-    (
-      icon: PhosphorIconsFill.chalkboard,
-      title: 'Screens',
-      route: '/internal/screens'
-    ),
-    (
-      icon: PhosphorIconsFill.books,
-      title: 'User Stories',
-      route: '/internal/user_stories'
+      icon: PhosphorIconsFill.appWindow,
+      title: 'Applications',
+      route: '/applications'
     ),
     (
       icon: PhosphorIconsFill.clock,
       title: 'Work Log',
-      route: '/internal/work_logs'
+      route: '/work_logs'
     )
   ];
 

--- a/apps/apprm/lib/features/work_log/pages/work_log_listing_page.dart
+++ b/apps/apprm/lib/features/work_log/pages/work_log_listing_page.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import '../../../constants/color.dart';
+import '../../common_object/widgets/listing/object_list_wrapper.dart';
+import '../../object/widgets/generic_item_card.dart';
+import '../../object/widgets/generic_list_empty.dart';
+import '../../common_object/mappers/work_log_mapper.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../../router.dart';
+
+class WorkLogListingPage extends StatelessWidget {
+  const WorkLogListingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundColor,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: false,
+        title: const Text('Work Log'),
+      ),
+      body: ObjectListWrapper(
+        objectType: 'work_logs',
+        mapperFn: WorkLogToObjectItemMapper.fromJson,
+        itemCardBuilder: (item) => GenericItemCard(item: item),
+        emptyBuilder: () => const GenericListEmpty(),
+        sortFields: const [
+          (key: 'created_at', label: 'Date', value: null),
+        ],
+        filterFields: const [],
+        searchFields: const ['description'],
+        onDetailNavigateFn: (id) async {
+          final data = await ObjectRepository().getObjectItem(
+            tableName: 'work_logs',
+            objectId: id,
+          );
+          final appId = data['app_id'] as String?;
+          if (appId != null) {
+            await ObjectDetailRoute(
+              appId: appId,
+              objectType: 'work_logs',
+              objectId: id,
+            ).push(context);
+          }
+        },
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -8,8 +8,10 @@ import 'features/auth/pages/azure_b2c_login_page.dart';
 import 'features/auth/pages/supabase_login_page.dart';
 import 'features/auth/pages/supabase_signup_page.dart';
 import 'features/application/pages/application_listing_page.dart';
-import 'features/application/pages/app_home_page.dart';
+import 'features/application/pages/application_home_page.dart';
 import 'features/application/pages/application_adding_page.dart';
+import 'features/home/pages/home_page.dart';
+import 'features/work_log/pages/work_log_listing_page.dart';
 import 'features/notification/pages/powersync_debug_page.dart';
 import 'features/object/pages/external_object_detail_page.dart';
 import 'features/object/pages/external_object_listing_page.dart';
@@ -114,21 +116,33 @@ class Auth0LoginRoute extends GoRouteData {
 class HomeRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const ApplicationListingPage();
+    return const HomePage();
   }
 }
 
-@TypedGoRoute<AppHomeRoute>(
+@TypedGoRoute<ApplicationHomeRoute>(
   path: '/app/:appId',
 )
-class AppHomeRoute extends GoRouteData {
-  const AppHomeRoute({required this.appId});
+class ApplicationHomeRoute extends GoRouteData {
+  const ApplicationHomeRoute({required this.appId});
 
   final String appId;
 
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return AppHomePage(appId: appId);
+    return ApplicationHomePage(appId: appId);
+  }
+}
+
+@TypedGoRoute<ApplicationListingRoute>(
+  path: '/applications',
+)
+class ApplicationListingRoute extends GoRouteData {
+  const ApplicationListingRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const ApplicationListingPage();
   }
 }
 
@@ -139,6 +153,18 @@ class ApplicationAddingRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return const ApplicationAddingPage();
+  }
+}
+
+@TypedGoRoute<WorkLogListingRoute>(
+  path: '/work_logs',
+)
+class WorkLogListingRoute extends GoRouteData {
+  const WorkLogListingRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const WorkLogListingPage();
   }
 }
 

--- a/apps/apprm/lib/router.g.dart
+++ b/apps/apprm/lib/router.g.dart
@@ -9,8 +9,10 @@ part of 'router.dart';
 List<RouteBase> get $appRoutes => [
       $authPageRoute,
       $homeRoute,
-      $appHomeRoute,
+      $applicationHomeRoute,
+      $applicationListingRoute,
       $applicationAddingRoute,
+      $workLogListingRoute,
       $objectListingRoute,
       $externalObjectListingRoute,
       $notificationRoute,
@@ -164,18 +166,42 @@ extension $HomeRouteExtension on HomeRoute {
   void replace(BuildContext context) => context.replace(location);
 }
 
-RouteBase get $appHomeRoute => GoRouteData.$route(
+RouteBase get $applicationHomeRoute => GoRouteData.$route(
       path: '/app/:appId',
-      factory: $AppHomeRouteExtension._fromState,
+      factory: $ApplicationHomeRouteExtension._fromState,
     );
 
-extension $AppHomeRouteExtension on AppHomeRoute {
-  static AppHomeRoute _fromState(GoRouterState state) => AppHomeRoute(
+extension $ApplicationHomeRouteExtension on ApplicationHomeRoute {
+  static ApplicationHomeRoute _fromState(GoRouterState state) =>
+      ApplicationHomeRoute(
         appId: state.pathParameters['appId']!,
       );
 
   String get location => GoRouteData.$location(
         '/app/${Uri.encodeComponent(appId)}',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $applicationListingRoute => GoRouteData.$route(
+      path: '/applications',
+      factory: $ApplicationListingRouteExtension._fromState,
+    );
+
+extension $ApplicationListingRouteExtension on ApplicationListingRoute {
+  static ApplicationListingRoute _fromState(GoRouterState state) =>
+      const ApplicationListingRoute();
+
+  String get location => GoRouteData.$location(
+        '/applications',
       );
 
   void go(BuildContext context) => context.go(location);
@@ -199,6 +225,29 @@ extension $ApplicationAddingRouteExtension on ApplicationAddingRoute {
 
   String get location => GoRouteData.$location(
         '/applications/add',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $workLogListingRoute => GoRouteData.$route(
+      path: '/work_logs',
+      factory: $WorkLogListingRouteExtension._fromState,
+    );
+
+extension $WorkLogListingRouteExtension on WorkLogListingRoute {
+  static WorkLogListingRoute _fromState(GoRouterState state) =>
+      const WorkLogListingRoute();
+
+  String get location => GoRouteData.$location(
+        '/work_logs',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- add a new simple HomePage used as the app landing page
- rename `AppHomePage` to `ApplicationHomePage`
- add ApplicationListingRoute and WorkLogListingRoute
- build a WorkLogListingPage to show work logs from all applications

## Testing
- `flutter test` *(fails: Supabase instance not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684779bdce388321817e9411ad398b02