### PR TITLE
Show user and app names on work log list

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -20,6 +20,16 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'profile',
+      [
+        Column.text('id'),
+        Column.text('email'),
+      ],
+      indexes: [
+        Index('profile_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'people',
       [
         Column.text('id'),
@@ -258,6 +268,7 @@ Schema schema = Schema(
         Column.text('created_at'),
         Column.text('updated_at'),
         Column.text('app_id'),
+        Column.text('user_id'),
         Column.text('amount'),
         Column.text('description'),
       ],

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -36,15 +36,17 @@ class ObjectRepository {
     }
 
     try {
-      // final results = await db.getAll(
-      //   'SELECT * FROM $tableName$sortStatement',
-      //   [
-      //     if (sortStatement.isNotEmpty)
-      //       sortValues.entries.map((e) => '${e.key} ${e.value}').join(', ')
-      //   ],
-      // );
+      String query = 'SELECT * FROM $tableName';
+      if (tableName == 'work_logs') {
+        query = '''
+          SELECT wl.*, p.email AS username, a.name AS app_name
+          FROM work_logs wl
+          LEFT JOIN profile p ON wl.user_id = p.id
+          LEFT JOIN applications a ON wl.app_id = a.id''';
+      }
+      query = '$query$filterStatement$sortStatement';
 
-      final results = await db.getAll('SELECT * FROM $tableName$filterStatement$sortStatement');
+      final results = await db.getAll(query);
 
       return results
           .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
@@ -59,7 +61,16 @@ class ObjectRepository {
     required String objectId,
   }) async {
     try {
-      final result = await db.get('SELECT * FROM $tableName WHERE id=?', [objectId]);
+      String query = 'SELECT * FROM $tableName WHERE id=?';
+      if (tableName == 'work_logs') {
+        query = '''
+          SELECT wl.*, p.email AS username, a.name AS app_name
+          FROM work_logs wl
+          LEFT JOIN profile p ON wl.user_id = p.id
+          LEFT JOIN applications a ON wl.app_id = a.id
+          WHERE wl.id = ?''';
+      }
+      final result = await db.get(query, [objectId]);
 
       return result.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value});
     } catch (e) {

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../common_object/widgets/managing/object_adding_wrapper.dart';
+import '../../../bootstrap/powersync.dart';
 
 class ObjectAddingPage extends StatefulWidget {
   const ObjectAddingPage({super.key});
@@ -343,13 +344,10 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final objectTypeParam =
-        GoRouterState.of(context).pathParameters['objectType']!;
+    final objectTypeParam = GoRouterState.of(context).pathParameters['objectType']!;
     final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
-    final dataObjectParam =
-        GoRouterState.of(context).queryParameters['data_object'];
-    final screenIdParam =
-        GoRouterState.of(context).queryParameters['screen_id'];
+    final dataObjectParam = GoRouterState.of(context).queryParameters['data_object'];
+    final screenIdParam = GoRouterState.of(context).queryParameters['screen_id'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectAddingWrapper(
@@ -368,6 +366,7 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
           [],
       extraData: {
         'app_id': appIdParam,
+        if (objectTypeParam == 'work_logs') 'user_id': getUserId(),
         if (dataObjectParam != null) 'data_object': dataObjectParam,
         if (screenIdParam != null) 'screen_id': screenIdParam,
       },


### PR DESCRIPTION
## Summary
- add `profile` table and `user_id` column for work logs
- include current user ID when creating work logs
- join `profile` and `applications` in work log queries

## Testing
- `flutter analyze`
- `flutter test` *(fails: compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_684826a9be8483218125e091063dcdec