### PR TITLE
Fix app title on application home page

### DIFF
--- a/apps/apprm/lib/features/application/pages/application_home_page.dart
+++ b/apps/apprm/lib/features/application/pages/application_home_page.dart
@@ -81,7 +81,13 @@ class _ApplicationHomePageState extends State<ApplicationHomePage> {
             ),
           ),
           builder: (context, state) {
-            return Text(state.data?['name'] ?? 'Home');
+            if (state.isLoading) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (state.hasError) {
+              return const Center(child: Text('Error loading data'));
+            } else {
+              return Text(state.data?['name'] ?? 'Home');
+            }
           },
         ),
         actions: [


### PR DESCRIPTION
## Summary
- fetch application item by ID on `ApplicationHomePage`
- show application name in the AppBar title

## Testing
- `flutter test` *(fails: Multiple exceptions during test execution)*

------
https://chatgpt.com/codex/tasks/task_e_68484ce07510832196f27e24593a069d