### PR TITLE
Fix detail menu order

### DIFF
--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -66,11 +66,11 @@ class ObjectDetailCard extends ConsumerWidget {
                 dataObjectId: objectId,
               ),
             if (objectType == 'screens') ...[
-              ScreenFunctionList(
-                screenId: objectId,
-              ),
               ScreenPhotoList(
                 appId: appId,
+                screenId: objectId,
+              ),
+              ScreenFunctionList(
                 screenId: objectId,
               ),
             ],


### PR DESCRIPTION
## Summary
- display screen photos before functions in the detail card

## Testing
- `flutter test` *(fails: Counter increments smoke test)*
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6848cec676648321aed01bcb876c8e5a