### PR TITLE
Add UI elements management

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -235,6 +235,47 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'elements',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('name'),
+        Column.text('description'),
+      ],
+      indexes: [
+        Index('elements_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
+      'screen_elements',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('screen_id'),
+        Column.text('element_id'),
+      ],
+      indexes: [
+        Index('screen_elements_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
+      'element_photos',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('element_id'),
+        Column.text('name'),
+        Column.text('description'),
+        Column.text('photo_id'),
+      ],
+      indexes: [
+        Index('element_photos_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'data_links',
       [
         Column.text('id'),

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
@@ -14,6 +14,7 @@ import 'data_field.dart';
 import 'data_link.dart';
 import 'screen.dart';
 import 'screen_function.dart';
+import 'ui_element.dart';
 import 'story.dart';
 import 'user_story.dart';
 import 'serialize_plugins/custom_8601_date_time_plugin.dart';
@@ -33,6 +34,7 @@ const List<Type> _registeredTypes = [
   DataField,
   Screen,
   ScreenFunction,
+  UiElement,
   DataLink,
   Story,
   UserStory,

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
@@ -19,6 +19,7 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(Screen.serializer)
       ..add(ScreenFunction.serializer)
       ..add(Story.serializer)
+      ..add(UiElement.serializer)
       ..add(UserStory.serializer))
     .build();
 

--- a/apps/apprm/lib/features/common_object/foundation/models/ui_element.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/ui_element.dart
@@ -1,0 +1,31 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'ui_element.g.dart';
+
+abstract class UiElement implements Built<UiElement, UiElementBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  String? get name;
+
+  String? get description;
+
+  UiElement._();
+  factory UiElement([void Function(UiElementBuilder) updates]) = _$UiElement;
+
+  static Serializer<UiElement> get serializer => _$uiElementSerializer;
+
+  factory UiElement.fromJson(Map<String, dynamic> json) =>
+      serializers.deserializeWith<UiElement>(serializer, json)!;
+
+  Map<String, dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/ui_element.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/ui_element.g.dart
@@ -1,0 +1,224 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ui_element.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<UiElement> _$uiElementSerializer = new _$UiElementSerializer();
+
+class _$UiElementSerializer implements StructuredSerializer<UiElement> {
+  @override
+  final Iterable<Type> types = const [UiElement, _$UiElement];
+  @override
+  final String wireName = 'UiElement';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UiElement object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.name;
+    if (value != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  UiElement deserialize(Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new UiElementBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UiElement extends UiElement {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? name;
+  @override
+  final String? description;
+
+  factory _$UiElement([void Function(UiElementBuilder)? updates]) =>
+      (new UiElementBuilder()..update(updates))._build();
+
+  _$UiElement._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.name,
+      this.description})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'UiElement', 'id');
+    BuiltValueNullFieldError.checkNotNull(createdAt, r'UiElement', 'createdAt');
+  }
+
+  @override
+  UiElement rebuild(void Function(UiElementBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UiElementBuilder toBuilder() => new UiElementBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UiElement &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        name == other.name &&
+        description == other.description;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UiElement')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('name', name)
+          ..add('description', description))
+        .toString();
+  }
+}
+
+class UiElementBuilder implements Builder<UiElement, UiElementBuilder> {
+  _$UiElement? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  UiElementBuilder();
+
+  UiElementBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _name = $v.name;
+      _description = $v.description;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UiElement other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UiElement;
+  }
+
+  @override
+  void update(void Function(UiElementBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UiElement build() => _build();
+
+  _$UiElement _build() {
+    final _$result = _$v ??
+        new _$UiElement._(
+            id: BuiltValueNullFieldError.checkNotNull(id, r'UiElement', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'UiElement', 'createdAt'),
+            updatedAt: updatedAt,
+            name: name,
+            description: description);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -193,6 +193,29 @@ class ObjectRepository {
     }
   }
 
+  Future<List<Map<String, dynamic>>> getScreenElements({
+    required String screenId,
+  }) async {
+    try {
+      final results = await db.getAll(
+        '''
+        SELECT e.*
+        FROM elements e
+        LEFT JOIN screen_elements se ON se.element_id = e.id
+        WHERE se.screen_id = ?
+        ''',
+        [screenId],
+      );
+
+      return results
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
+          .toList();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   Future connectToExternalObject({
     required String objectType,
     required String objectId,

--- a/apps/apprm/lib/features/common_object/foundation/use_cases/get_screen_elements_usecase.dart
+++ b/apps/apprm/lib/features/common_object/foundation/use_cases/get_screen_elements_usecase.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../object_repository.dart';
+import 'common_usecase.dart';
+
+final getScreenElementsProvider = Provider<GetScreenElementsUseCase>(
+  (ref) => GetScreenElementsUseCase(
+    objectRepository: ref.read(objectRepositoryProvider),
+  ),
+);
+
+class GetScreenElementsUseCase
+    implements ParamsUseCase<Future<List<Map<String, dynamic>>>, GetScreenElementsUseCaseParams> {
+  final ObjectRepository objectRepository;
+
+  GetScreenElementsUseCase({required this.objectRepository});
+
+  @override
+  execute(params) {
+    return objectRepository.getScreenElements(screenId: params.screenId);
+  }
+}
+
+class GetScreenElementsUseCaseParams {
+  final String screenId;
+
+  GetScreenElementsUseCaseParams({required this.screenId});
+}

--- a/apps/apprm/lib/features/common_object/mappers/ui_element_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/ui_element_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/ui_element.dart';
+
+class UiElementToObjectItemMapper {
+  static ObjectItem fromModel(UiElement item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.name ?? '',
+      subTitle: item.description ?? '',
+      sortFields: [
+        (key: 'name', label: 'Name'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(UiElement.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -3,6 +3,8 @@ import 'package:apprm/features/common_object/widgets/detail/data_field_list.dart
 import 'package:apprm/features/screens/widgets/screen_photo_list.dart';
 import 'package:apprm/features/screens/widgets/screen_function_list.dart';
 import 'package:apprm/features/screens/widgets/data_link_list.dart';
+import 'package:apprm/features/screens/widgets/element_list.dart';
+import 'package:apprm/features/screens/widgets/element_photo_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -73,11 +75,18 @@ class ObjectDetailCard extends ConsumerWidget {
               ScreenFunctionList(
                 screenId: objectId,
               ),
+              ElementList(
+                screenId: objectId,
+              ),
             ],
             if (objectType == 'screen_functions')
               DataLinkList(
                 appId: appId,
                 functionId: objectId,
+              ),
+            if (objectType == 'elements')
+              ElementPhotoList(
+                elementId: objectId,
               ),
           ],
         ),

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -145,6 +145,27 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         ),
       ],
     ),
+    'elements': (
+      label: 'element',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'screen_functions': (
       label: 'function',
       inputFields: [

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -13,6 +13,7 @@ import '../../common_object/mappers/story_mapper.dart';
 import '../../common_object/mappers/user_story_mapper.dart';
 import '../../common_object/mappers/data_field_mapper.dart';
 import '../../common_object/mappers/screen_function_mapper.dart';
+import '../../common_object/mappers/ui_element_mapper.dart';
 import '../../common_object/mappers/work_log_mapper.dart';
 import '../../common_object/widgets/detail/object_detail_wrapper.dart';
 
@@ -59,6 +60,13 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
     ),
     'screens': (
       dataMapperFn: ScreenToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+      ],
+    ),
+    'elements': (
+      dataMapperFn: UiElementToObjectItemMapper.fromJson,
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -175,6 +175,27 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'elements': (
+      label: 'element',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'screen_functions': (
       label: 'function',
       inputFields: [

--- a/apps/apprm/lib/features/screens/pages/screen_element_adding_page.dart
+++ b/apps/apprm/lib/features/screens/pages/screen_element_adding_page.dart
@@ -1,0 +1,116 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+import '../../../constants/color.dart';
+import '../../common_object/foundation/object_repository.dart';
+
+class ScreenElementAddingPage extends ConsumerStatefulWidget {
+  const ScreenElementAddingPage({super.key, required this.appId, required this.screenId});
+
+  final String appId;
+  final String screenId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ScreenElementAddingPageState();
+}
+
+class _ScreenElementAddingPageState extends ConsumerState<ScreenElementAddingPage> {
+  late FormGroup formGroup;
+  final ObjectRepository _repository = ObjectRepository();
+
+  @override
+  void initState() {
+    formGroup = FormGroup({
+      'name': FormControl<String>(),
+      'description': FormControl<String>(),
+    });
+    super.initState();
+  }
+
+  Future<void> _save() async {
+    formGroup.markAllAsTouched();
+    if (formGroup.valid) {
+      try {
+        EasyLoading.show(status: 'Creating...');
+        final elementId = await _repository.createObject(
+          tableName: 'elements',
+          data: {
+            'name': formGroup.control('name').value,
+            'description': formGroup.control('description').value,
+          },
+        );
+        if (elementId != null) {
+          await _repository.createObject(
+            tableName: 'screen_elements',
+            data: {
+              'screen_id': widget.screenId,
+              'element_id': elementId,
+            },
+          );
+        }
+        CachedQuery.instance.refetchQueries(keys: [
+          ['screen_elements', 'list', widget.screenId]
+        ]);
+        if (context.mounted) {
+          context.pop(true);
+        }
+      } catch (e) {
+        EasyLoading.showError(e.toString());
+      } finally {
+        EasyLoading.dismiss();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: false,
+        title: const Text('New element'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: TextButton.icon(
+              onPressed: _save,
+              icon: const Icon(PhosphorIconsBold.check),
+              label: const Text('Add'),
+              style: IconButton.styleFrom(
+                foregroundColor: AppColors.primaryColor,
+              ),
+            ),
+          )
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: ReactiveForm(
+          formGroup: formGroup,
+          child: Wrap(
+            runSpacing: 16,
+            children: [
+              const Text('Name'),
+              ReactiveTextField(
+                formControlName: 'name',
+                decoration: const InputDecoration(border: OutlineInputBorder()),
+              ),
+              const Text('Description'),
+              ReactiveTextField(
+                formControlName: 'description',
+                decoration: const InputDecoration(border: OutlineInputBorder()),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/screens/widgets/element_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/element_list.dart
@@ -1,0 +1,127 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:apprm/router.dart';
+
+import '../../../constants/color.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_screen_elements_usecase.dart';
+
+class ElementList extends ConsumerStatefulWidget {
+  const ElementList({super.key, required this.screenId});
+
+  final String screenId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ElementListState();
+}
+
+class _ElementListState extends ConsumerState<ElementList> {
+  void onRefresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['screen_elements', 'list', widget.screenId]
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Elements',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'screen_elements',
+                  'list',
+                  widget.screenId,
+                ],
+                queryFn: () async {
+                  return await GetScreenElementsUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetScreenElementsUseCaseParams(screenId: widget.screenId),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: Duration(seconds: 1),
+                  refetchDuration: Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (state.data?.isEmpty ?? true)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...state.data!.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final result = await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'elements',
+                            objectId: e['id'],
+                          ).push(context);
+                          if (result == true) {
+                            onRefresh();
+                          }
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['name'] ?? '--',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: () async {
+                        await ScreenElementAddingRoute(
+                                appId: appIdParam,
+                                screenId: widget.screenId)
+                            .push(context);
+                        onRefresh();
+                      },
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/screens/widgets/element_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/element_photo_list.dart
@@ -1,0 +1,271 @@
+import 'dart:io';
+
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../attachments/queue.dart';
+import '../../../constants/color.dart';
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/create_object_usecase.dart';
+import '../../common_object/foundation/use_cases/delete_object_item_usecase.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+
+class ElementPhotoList extends ConsumerStatefulWidget {
+  const ElementPhotoList({super.key, required this.elementId});
+
+  final String elementId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _ElementPhotoListState();
+}
+
+class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
+  final ImagePicker _picker = ImagePicker();
+
+  final _createMutation = Mutation<void, CreateObjectUseCaseParams>(
+    queryFn: (params) => CreateObjectUseCase(
+      objectRepository: ObjectRepository(),
+    ).execute(params),
+  );
+
+  final _deleteMutation = Mutation<void, DeleteObjectItemUseCaseParams>(
+    queryFn: (params) => DeleteObjectItemUseCase(
+      objectRepository: ObjectRepository(),
+    ).execute(params),
+  );
+
+  void _refresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['element_photos', 'list', widget.elementId]
+    ]);
+  }
+
+  Future<void> _addPhoto() async {
+    final XFile? file = await _picker.pickImage(source: ImageSource.gallery);
+    if (file == null) return;
+
+    final bytes = await file.readAsBytes();
+    final photoId = const Uuid().v4();
+    final filename = '$photoId.jpg';
+    final localUri = await attachmentQueue.getLocalUri(filename);
+
+    final destDir = Directory(localUri).parent;
+    if (!await destDir.exists()) {
+      await destDir.create(recursive: true);
+    }
+
+    await attachmentQueue.localStorage.copyFile(file.path, localUri);
+    await attachmentQueue.saveFile(photoId, bytes.length);
+
+    await _createMutation.mutate(
+      CreateObjectUseCaseParams(
+        objectType: 'element_photos',
+        data: {
+          'element_id': widget.elementId,
+          'name': file.name,
+          'photo_id': photoId,
+        },
+      ),
+    );
+
+    _refresh();
+  }
+
+  Future<void> _deletePhoto(Map<String, dynamic> item) async {
+    await attachmentQueue.deleteFile(item['photo_id']);
+    await _deleteMutation.mutate(
+      DeleteObjectItemUseCaseParams(
+        objectType: 'element_photos',
+        objectId: item['id'],
+      ),
+    );
+    _refresh();
+  }
+
+  Future<void> _openFullScreenImage(String path) async {
+    if (!mounted) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => Scaffold(
+          backgroundColor: Colors.black,
+          body: GestureDetector(
+            onTap: () => Navigator.of(context).pop(),
+            onDoubleTap: () => Navigator.of(context).pop(),
+            child: Center(
+              child: InteractiveViewer(
+                child: Image.file(File(path)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openPhotoDetail(Map<String, dynamic> item) async {
+    final localPath =
+        await attachmentQueue.getLocalUri('${item['photo_id']}.jpg');
+    if (!mounted) return;
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                GestureDetector(
+                  onTap: () => _openFullScreenImage(localPath),
+                  onDoubleTap: () => _openFullScreenImage(localPath),
+                  child: Image.file(File(localPath)),
+                ),
+                const SizedBox(height: 8),
+                Text(item['name'] ?? '',
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 4),
+                Text(item['description'] ?? '--'),
+                const SizedBox(height: 4),
+                Text('ID: ${item['photo_id']}'),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                ObjectUpdatingRoute(
+                  appId: GoRouterState.of(context).pathParameters['appId']!,
+                  objectType: 'element_photos',
+                  objectId: item['id'],
+                ).push(context);
+              },
+              child: const Text('Edit'),
+            ),
+            TextButton(
+              onPressed: () async {
+                Navigator.of(context).pop();
+                await _deletePhoto(item);
+              },
+              style: TextButton.styleFrom(foregroundColor: Colors.red),
+              child: const Text('Delete'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Photos',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'element_photos',
+                  'list',
+                  widget.elementId,
+                ],
+                queryFn: () async {
+                  return await GetObjectListUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetObjectListUseCaseParams(
+                      objectType: 'element_photos',
+                      sortValues: const {},
+                      filterValues: {'element_id': widget.elementId},
+                      searchFields: const ['name'],
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: Duration(seconds: 1),
+                  refetchDuration: Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              final list = state.data ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (list.isEmpty)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: list.map((e) {
+                        return FutureBuilder<String>(
+                          future: attachmentQueue
+                              .getLocalUri('${e['photo_id']}.jpg'),
+                          builder: (context, snapshot) {
+                            if (!snapshot.hasData) {
+                              return const SizedBox(
+                                width: 80,
+                                height: 80,
+                                child:
+                                    Center(child: CircularProgressIndicator()),
+                              );
+                            }
+                            final file = File(snapshot.data!);
+                            return InkWell(
+                              onTap: () => _openPhotoDetail(e),
+                              child: Image.file(
+                                file,
+                                width: 80,
+                                height: 80,
+                                fit: BoxFit.cover,
+                              ),
+                            );
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: _addPhoto,
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -19,7 +19,7 @@ import 'features/object/pages/object_adding_page.dart';
 import 'features/object/pages/object_detail_page.dart';
 import 'features/object/pages/object_listing_page.dart';
 import 'features/object/pages/object_updating_page.dart';
-import 'features/notification/pages/powersync_debug_page.dart';
+import 'features/screens/pages/screen_element_adding_page.dart';
 
 part 'router.g.dart';
 
@@ -231,6 +231,21 @@ class ObjectUpdatingRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return ObjectUpdatingPage(objectId: objectId);
+  }
+}
+
+@TypedGoRoute<ScreenElementAddingRoute>(
+  path: '/app/:appId/screens/:screenId/elements/add',
+)
+class ScreenElementAddingRoute extends GoRouteData {
+  const ScreenElementAddingRoute({required this.appId, required this.screenId});
+
+  final String appId;
+  final String screenId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return ScreenElementAddingPage(appId: appId, screenId: screenId);
   }
 }
 

--- a/apps/apprm/lib/router.g.dart
+++ b/apps/apprm/lib/router.g.dart
@@ -14,6 +14,7 @@ List<RouteBase> get $appRoutes => [
       $applicationAddingRoute,
       $workLogListingRoute,
       $objectListingRoute,
+      $screenElementAddingRoute,
       $externalObjectListingRoute,
       $notificationRoute,
     ];
@@ -353,6 +354,32 @@ extension $ObjectUpdatingRouteExtension on ObjectUpdatingRoute {
 
   String get location => GoRouteData.$location(
         '/app/${Uri.encodeComponent(appId)}/internal/${Uri.encodeComponent(objectType)}/${Uri.encodeComponent(objectId)}/update',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $screenElementAddingRoute => GoRouteData.$route(
+      path: '/app/:appId/screens/:screenId/elements/add',
+      factory: $ScreenElementAddingRouteExtension._fromState,
+    );
+
+extension $ScreenElementAddingRouteExtension on ScreenElementAddingRoute {
+  static ScreenElementAddingRoute _fromState(GoRouterState state) =>
+      ScreenElementAddingRoute(
+        appId: state.pathParameters['appId']!,
+        screenId: state.pathParameters['screenId']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/app/${Uri.encodeComponent(appId)}/screens/${Uri.encodeComponent(screenId)}/elements/add',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- add new database tables for elements, element photos and screen links
- add UiElement model and mapping utilities
- list screen elements and element photos on detail pages
- allow creating elements with photos and linking them to screens
- generate routing for screen element page

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68498e171364832182b44aeb34e01ca8