### PR TITLE
Add navigation records to screens

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -290,6 +290,21 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'navigations',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('navigation_from'),
+        Column.text('navigation_from_type'),
+        Column.text('navigation_to'),
+        Column.text('navigation_to_type'),
+      ],
+      indexes: [
+        Index('navigations_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'user_stories',
       [
         Column.text('id'),

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -216,6 +216,31 @@ class ObjectRepository {
     }
   }
 
+  Future<List<Map<String, dynamic>>> getNavigations({
+    required String fromId,
+    required String fromType,
+  }) async {
+    try {
+      final results = await db.getAll(
+        '''
+        SELECT n.*, s.name AS screen_name, sf.name AS function_name
+        FROM navigations n
+        LEFT JOIN screens s ON n.navigation_to = s.id AND n.navigation_to_type = 'screen'
+        LEFT JOIN screen_functions sf ON sf.id = n.navigation_to AND n.navigation_to_type = 'function'
+        WHERE n.navigation_from = ? AND n.navigation_from_type = ?
+        ''',
+        [fromId, fromType],
+      );
+
+      return results
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
+          .toList();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   Future connectToExternalObject({
     required String objectType,
     required String objectId,

--- a/apps/apprm/lib/features/common_object/foundation/use_cases/get_navigations_usecase.dart
+++ b/apps/apprm/lib/features/common_object/foundation/use_cases/get_navigations_usecase.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../object_repository.dart';
+import 'common_usecase.dart';
+
+final getNavigationsProvider = Provider<GetNavigationsUseCase>(
+  (ref) => GetNavigationsUseCase(
+    objectRepository: ref.read(objectRepositoryProvider),
+  ),
+);
+
+class GetNavigationsUseCase
+    implements
+        ParamsUseCase<Future<List<Map<String, dynamic>>>,
+            GetNavigationsUseCaseParams> {
+  final ObjectRepository objectRepository;
+
+  GetNavigationsUseCase({required this.objectRepository});
+
+  @override
+  execute(params) {
+    return objectRepository.getNavigations(
+      fromId: params.fromId,
+      fromType: params.fromType,
+    );
+  }
+}
+
+class GetNavigationsUseCaseParams {
+  final String fromId;
+  final String fromType;
+
+  GetNavigationsUseCaseParams({required this.fromId, required this.fromType});
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -5,6 +5,7 @@ import 'package:apprm/features/screens/widgets/screen_function_list.dart';
 import 'package:apprm/features/screens/widgets/data_link_list.dart';
 import 'package:apprm/features/screens/widgets/element_list.dart';
 import 'package:apprm/features/screens/widgets/element_photo_list.dart';
+import 'package:apprm/features/screens/widgets/navigation_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,6 +16,7 @@ class ObjectDetailCard extends ConsumerWidget {
     required this.objectType,
     required this.objectId,
     required this.appId,
+    this.screenId,
     required this.displayFields,
     this.objectItem,
   });
@@ -22,6 +24,7 @@ class ObjectDetailCard extends ConsumerWidget {
   final String objectType;
   final String objectId;
   final String appId;
+  final String? screenId;
   final List<DisplayField> displayFields;
   final Map<String, dynamic>? objectItem;
 
@@ -84,9 +87,23 @@ class ObjectDetailCard extends ConsumerWidget {
                 appId: appId,
                 functionId: objectId,
               ),
+            if (objectType == 'screen_functions')
+              NavigationList(
+                appId: appId,
+                objectId: objectId,
+                objectType: 'function',
+                screenId: objectItem?['screen_id'],
+              ),
             if (objectType == 'elements')
               ElementPhotoList(
                 elementId: objectId,
+              ),
+            if (objectType == 'elements')
+              NavigationList(
+                appId: appId,
+                objectId: objectId,
+                objectType: 'element',
+                screenId: screenId,
               ),
           ],
         ),

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_wrapper.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_wrapper.dart
@@ -26,11 +26,13 @@ class ObjectDetailWrapper extends ConsumerStatefulWidget {
     required this.mapperFn,
     required this.displayFields,
     required this.onEditingNavigateFn,
+    this.screenId,
   });
 
   final String objectType;
   final String objectId;
   final String appId;
+  final String? screenId;
   final ObjectItem Function(Map<String, dynamic>) mapperFn;
   final List<DisplayField> displayFields;
   final VoidCallback onEditingNavigateFn;
@@ -193,6 +195,7 @@ class _ObjectDetailWrapperState extends ConsumerState<ObjectDetailWrapper> {
                 objectType: widget.objectType,
                 objectId: widget.objectId,
                 appId: widget.appId,
+                screenId: widget.screenId,
                 displayFields: widget.displayFields,
                 objectItem: state.data,
               ),

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -126,12 +126,15 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
         GoRouterState.of(context).pathParameters['objectType']!;
     final objectIdParam = GoRouterState.of(context).pathParameters['objectId']!;
     final appIdParam = GoRouterState.of(context).pathParameters['appId'];
+    final screenIdParam =
+        GoRouterState.of(context).queryParameters['screen_id'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectDetailWrapper(
       objectType: objectTypeParam,
       objectId: objectIdParam,
       appId: appIdParam!,
+      screenId: screenIdParam,
       mapperFn: objectData?.dataMapperFn ?? (e) => ObjectItem.fromJson(e),
       displayFields: objectData?.displayFields
               .map((e) => (key: e.key, label: e.label))

--- a/apps/apprm/lib/features/screens/widgets/element_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/element_list.dart
@@ -54,7 +54,8 @@ class _ElementListState extends ConsumerState<ElementList> {
           .push(context);
       onRefresh();
     } else if (option == 'existing') {
-      final selectedScreen = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+      final selectedScreen =
+          await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
         context: context,
         builder: (_) => ScreenSelection(
           appId: appId,
@@ -63,7 +64,8 @@ class _ElementListState extends ConsumerState<ElementList> {
       );
       if (selectedScreen == null) return;
 
-      final selectedElement = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+      final selectedElement =
+          await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
         context: context,
         builder: (_) => ElementSelection(screenId: selectedScreen['id']),
       );
@@ -130,11 +132,9 @@ class _ElementListState extends ConsumerState<ElementList> {
                     ...state.data!.map(
                       (e) => InkWell(
                         onTap: () async {
-                          final result = await ObjectDetailRoute(
-                            appId: appIdParam,
-                            objectType: 'elements',
-                            objectId: e['id'],
-                          ).push(context);
+                          final result = await context.push(
+                            '/app/$appIdParam/internal/elements/${e['id']}?screen_id=${widget.screenId}',
+                          );
                           if (result == true) {
                             onRefresh();
                           }

--- a/apps/apprm/lib/features/screens/widgets/function_selection.dart
+++ b/apps/apprm/lib/features/screens/widgets/function_selection.dart
@@ -1,0 +1,54 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+
+class FunctionSelection extends ConsumerWidget {
+  const FunctionSelection({super.key, required this.screenId});
+
+  final String screenId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      child: SizedBox(
+        height: 400,
+        child: QueryBuilder<List<Map<String, dynamic>>>(
+          query: Query(
+            key: ['screen_functions', 'select', screenId],
+            queryFn: () async {
+              return await GetObjectListUseCase(
+                objectRepository: ObjectRepository(),
+              ).execute(
+                GetObjectListUseCaseParams(
+                  objectType: 'screen_functions',
+                  sortValues: const {},
+                  filterValues: {'screen_id': screenId},
+                  searchFields: const ['name'],
+                ),
+              );
+            },
+          ),
+          builder: (context, state) {
+            final list = state.data ?? [];
+            return ListView.separated(
+              itemCount: list.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (_, idx) {
+                final item = list[idx];
+                return ListTile(
+                  title: Text(item['name'] ?? '--'),
+                  onTap: () {
+                    Navigator.of(context).pop(item);
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/screens/widgets/navigation_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/navigation_list.dart
@@ -1,0 +1,214 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../constants/color.dart';
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/create_object_usecase.dart';
+import '../../common_object/foundation/use_cases/get_navigations_usecase.dart';
+import 'function_selection.dart';
+import 'screen_selection.dart';
+
+class NavigationList extends ConsumerStatefulWidget {
+  const NavigationList({
+    super.key,
+    required this.appId,
+    required this.objectId,
+    required this.objectType,
+    this.screenId,
+  });
+
+  final String appId;
+  final String objectId;
+  final String objectType; // 'element' or 'function'
+  final String? screenId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _NavigationListState();
+}
+
+class _NavigationListState extends ConsumerState<NavigationList> {
+  final _createMutation = Mutation<void, CreateObjectUseCaseParams>(
+    queryFn: (params) => CreateObjectUseCase(
+      objectRepository: ObjectRepository(),
+    ).execute(params),
+  );
+
+  void _refresh() {
+    CachedQuery.instance.refetchQueries(
+        keys: ['navigations', 'list', widget.objectId, widget.objectType]);
+  }
+
+  Future<void> _addNavigation() async {
+    final option = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Text('Add Navigation'),
+          children: [
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop('function'),
+              child: const Text('To a function'),
+            ),
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop('screen'),
+              child: const Text('To a screen'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (option == null) return;
+
+    if (option == 'screen') {
+      final selectedScreen =
+          await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+        context: context,
+        builder: (_) => ScreenSelection(appId: widget.appId),
+      );
+      if (selectedScreen == null) return;
+
+      await _createMutation.mutate(
+        CreateObjectUseCaseParams(
+          objectType: 'navigations',
+          data: {
+            'navigation_from': widget.objectId,
+            'navigation_from_type': widget.objectType,
+            'navigation_to': selectedScreen['id'],
+            'navigation_to_type': 'screen',
+          },
+        ),
+      );
+    } else if (option == 'function') {
+      if (widget.screenId == null) return;
+
+      final selectedFunction =
+          await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+        context: context,
+        builder: (_) => FunctionSelection(screenId: widget.screenId!),
+      );
+      if (selectedFunction == null) return;
+
+      await _createMutation.mutate(
+        CreateObjectUseCaseParams(
+          objectType: 'navigations',
+          data: {
+            'navigation_from': widget.objectId,
+            'navigation_from_type': widget.objectType,
+            'navigation_to': selectedFunction['id'],
+            'navigation_to_type': 'function',
+          },
+        ),
+      );
+    }
+
+    _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = widget.appId;
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Navigation',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'navigations',
+                  'list',
+                  widget.objectId,
+                  widget.objectType,
+                ],
+                queryFn: () async {
+                  return await GetNavigationsUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetNavigationsUseCaseParams(
+                      fromId: widget.objectId,
+                      fromType: widget.objectType,
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: const Duration(seconds: 1),
+                  refetchDuration: const Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              final list = state.data ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (list.isEmpty)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...list.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final toType = e['navigation_to_type'] as String?;
+                          final toId = e['navigation_to'] as String?;
+                          if (toType == null || toId == null) return;
+                          await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: toType == 'screen'
+                                ? 'screens'
+                                : 'screen_functions',
+                            objectId: toId,
+                          ).push(context);
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['navigation_to_type'] == 'screen'
+                                ? (e['screen_name'] ?? e['navigation_to'])
+                                : (e['function_name'] ?? e['navigation_to']),
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: _addNavigation,
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `navigations` table to DB schema
- support retrieving navigations in repository
- add use case for navigation queries
- provide UI widgets to manage navigations
- hook navigation list into object detail pages
- pass screen id when opening element details

## Testing
- `flutter pub get`
- `flutter analyze` *(shows warnings)*
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_6849f97c70188321ac0276b11b54021a