### PR TITLE
Remove icons from history items

### DIFF
--- a/apps/apprm/lib/features/history/pages/history_listing_page.dart
+++ b/apps/apprm/lib/features/history/pages/history_listing_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../../constants/color.dart';
 import '../../common_object/widgets/listing/object_list_wrapper.dart';
-import '../../object/widgets/generic_item_card.dart';
+import '../widgets/history_item_card.dart';
 import '../../object/widgets/generic_list_empty.dart';
 import '../../common_object/mappers/history_mapper.dart';
 
@@ -22,7 +22,7 @@ class HistoryListingPage extends StatelessWidget {
       body: ObjectListWrapper(
         objectType: 'history',
         mapperFn: HistoryToObjectItemMapper.fromJson,
-        itemCardBuilder: (item) => GenericItemCard(item: item),
+        itemCardBuilder: (item) => HistoryItemCard(item: item),
         emptyBuilder: GenericListEmpty.new,
         sortFields: [
           (key: 'created_at', label: 'Date', value: null),

--- a/apps/apprm/lib/features/history/widgets/history_item_card.dart
+++ b/apps/apprm/lib/features/history/widgets/history_item_card.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../common_object/entities/object_item.dart';
+
+class HistoryItemCard extends ConsumerWidget {
+  const HistoryItemCard({super.key, required this.item});
+
+  final ObjectItem item;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListTile(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      contentPadding: const EdgeInsets.symmetric(
+        vertical: 12,
+        horizontal: 16,
+      ),
+      selected: true,
+      selectedTileColor: Colors.white,
+      title: Text(item.title),
+      subtitle: item.subTitle != null ? Text(item.subTitle!) : null,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- clean up the History listing page UI
- show text-only cards for history items

## Testing
- `flutter analyze`
- `flutter test` *(fails: Supabase not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684acdbe559883218677665f88f43011