### PR TITLE
Implement application secret encryption

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -341,6 +341,7 @@ Schema schema = Schema(
         Column.text('updated_at'),
         Column.text('name'),
         Column.text('description'),
+        Column.text('secret'),
       ],
       indexes: [
         Index('applications_list', [IndexedColumn('id')])

--- a/apps/apprm/lib/features/common_object/foundation/models/application.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/application.dart
@@ -4,6 +4,7 @@ class Application {
   final DateTime? updatedAt;
   final String? name;
   final String? description;
+  final String? secret;
 
   Application({
     required this.id,
@@ -11,16 +12,19 @@ class Application {
     this.updatedAt,
     this.name,
     this.description,
+    this.secret,
   });
 
   factory Application.fromJson(Map<String, dynamic> json) {
     return Application(
       id: json['id'] as String,
       createdAt: DateTime.parse(json['created_at'] as String),
-      updatedAt:
-          json['updated_at'] != null ? DateTime.parse(json['updated_at']) : null,
+      updatedAt: json['updated_at'] != null
+          ? DateTime.parse(json['updated_at'])
+          : null,
       name: json['name'] as String?,
       description: json['description'] as String?,
+      secret: json['secret'] as String?,
     );
   }
 
@@ -30,5 +34,6 @@ class Application {
         'updated_at': updatedAt?.toIso8601String(),
         'name': name,
         'description': description,
+        'secret': secret,
       };
 }

--- a/apps/apprm/lib/utils/crypt.dart
+++ b/apps/apprm/lib/utils/crypt.dart
@@ -13,9 +13,7 @@ String executeEncrypt(String plainText, String secret) {
   final encrypter = enc.Encrypter(enc.AES(key, mode: enc.AESMode.cbc));
 
   final encrypted = encrypter.encrypt(plainText, iv: iv);
-  final decrypted = encrypter.decrypt(encrypted, iv: iv);
 
-  //print(decrypted); // Lorem ipsum dolor sit amet, consectetur adipiscing elit
   //print(encrypted.base64);
 
   String encTxt =

--- a/apps/apprm/pubspec.lock
+++ b/apps/apprm/pubspec.lock
@@ -77,6 +77,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.0"
+  asn1lib:
+    dependency: transitive
+    description:
+      name: asn1lib
+      sha256: "4bae5ae63e6d6dd17c4aac8086f3dec26c0236f6a0f03416c6c19d830c367cf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.8"
   async:
     dependency: transitive
     description:
@@ -301,6 +309,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  encrypt:
+    dependency: "direct main"
+    description:
+      name: encrypt
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -889,6 +905,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
@@ -994,7 +1018,7 @@ packages:
     source: hosted
     version: "0.28.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"

--- a/apps/apprm/pubspec.yaml
+++ b/apps/apprm/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   pull_down_button: ^0.10.1
   easy_debounce: ^2.0.3
   encrypt: ^5.0.1
+  shared_preferences: ^2.3.2
 
   aad_b2c_webview:
     path: ../../libs/aad_b2c_webview


### PR DESCRIPTION
## Summary
- support storing application secrets with SharedPreferences
- encrypt/decrypt using AES helper
- manage secret setup and verification on ApplicationHomePage
- add secret column in database schema
- include shared_preferences dependency

## Testing
- `flutter pub get`
- `flutter test` *(fails: Supabase instance not initialized)*
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_684aff76c33c8321993628f367262e78