### PR TITLE
Add admin screen with application assignment

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -348,6 +348,19 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'application_users',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('app_id'),
+        Column.text('user_id'),
+      ],
+      indexes: [
+        Index('application_users_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'actions',
       [
         Column.text('id'),

--- a/apps/apprm/lib/features/admin/pages/admin_page.dart
+++ b/apps/apprm/lib/features/admin/pages/admin_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+import '../../../bootstrap/powersync.dart';
+import '../../../constants/color.dart';
+
+class AdminPage extends StatefulWidget {
+  const AdminPage({super.key});
+
+  @override
+  State<AdminPage> createState() => _AdminPageState();
+}
+
+class _AdminPageState extends State<AdminPage> {
+  List<Map<String, dynamic>> _users = [];
+  List<Map<String, dynamic>> _apps = [];
+  Set<String> _assignments = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final users = await db.getAll(
+        "SELECT id, name FROM profile WHERE name IS NOT NULL ORDER BY name");
+    final apps =
+        await db.getAll("SELECT id, name FROM applications ORDER BY name");
+    final assigns =
+        await db.getAll('SELECT user_id, app_id FROM application_users');
+    setState(() {
+      _users = users;
+      _apps = apps;
+      _assignments =
+          assigns.map((e) => '${e['user_id']}_${e['app_id']}').toSet();
+    });
+  }
+
+  Future<void> _toggle(String userId, String appId, String appName) async {
+    final key = '${userId}_$appId';
+    final assigned = _assignments.contains(key);
+    if (assigned) {
+      await db.execute(
+          "DELETE FROM application_users WHERE user_id=? AND app_id=?",
+          [userId, appId]);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Unassigned from $appName')));
+      }
+    } else {
+      await db.execute(
+          "INSERT INTO application_users(id, created_at, updated_at, app_id, user_id) VALUES (uuid(), datetime(), datetime(), ?, ?)",
+          [appId, userId]);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Assigned to $appName')));
+      }
+    }
+    _loadData();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundColor,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        centerTitle: false,
+        title: const Text('Admin'),
+      ),
+      body: _users.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemBuilder: (_, idx) {
+                final user = _users[idx];
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      user['name'] ?? '',
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Wrap(
+                        spacing: 8,
+                        children: _apps.map((app) {
+                          final assigned = _assignments
+                              .contains('${user['id']}_${app['id']}');
+                          return ElevatedButton(
+                            onPressed: () => _toggle(
+                                user['id'], app['id'], app['name'] as String),
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: assigned
+                                  ? AppColors.primaryColor
+                                  : Colors.grey,
+                              foregroundColor: Colors.white,
+                            ),
+                            child: Text(app['name']),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                  ],
+                );
+              },
+              separatorBuilder: (_, __) => const SizedBox(height: 16),
+              itemCount: _users.length,
+            ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -16,18 +16,22 @@ class ObjectRepository {
   }) async {
     var sortStatement = "";
     if (sortValues.isNotEmpty) {
-      final orderByKey = sortValues.entries.map((e) => '${e.key} ${e.value}').join(', ');
+      final orderByKey =
+          sortValues.entries.map((e) => '${e.key} ${e.value}').join(', ');
       sortStatement = " ORDER BY $orderByKey";
     }
 
     var filterStatement = "";
     if (filterValues.isNotEmpty) {
-      final conditionByKey = filterValues.entries.map((e) => '${e.key}=\'${e.value}\'').join(' AND ');
+      final conditionByKey = filterValues.entries
+          .map((e) => '${e.key}=\'${e.value}\'')
+          .join(' AND ');
       filterStatement = " WHERE $conditionByKey";
     }
 
     if (searchValue?.isNotEmpty ?? false) {
-      final searchStatement = searchFields.map((e) => '$e LIKE \'%$searchValue%\'').join(' OR ');
+      final searchStatement =
+          searchFields.map((e) => '$e LIKE \'%$searchValue%\'').join(' OR ');
       if (filterStatement.isNotEmpty) {
         filterStatement = "$filterStatement $searchStatement";
       } else {
@@ -49,13 +53,24 @@ class ObjectRepository {
           FROM history h
           LEFT JOIN profile p ON h.user_id = p.id
           LEFT JOIN applications a ON h.app_id = a.id''';
+      } else if (tableName == 'applications') {
+        final userId = getUserId();
+        if (userId != null) {
+          query = '''
+            SELECT a.*
+            FROM applications a
+            LEFT JOIN application_users au ON au.app_id = a.id
+            WHERE au.user_id = '$userId'
+          ''';
+        }
       }
       query = '$query$filterStatement$sortStatement';
 
       final results = await db.getAll(query);
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -85,7 +100,8 @@ class ObjectRepository {
       }
       final result = await db.get(query, [objectId]);
 
-      return result.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value});
+      return result.entries
+          .fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value});
     } catch (e) {
       rethrow;
     }
@@ -99,7 +115,8 @@ class ObjectRepository {
       final results = await db.getAll('SELECT DISTINCT $field FROM $tableName');
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -123,7 +140,8 @@ class ObjectRepository {
       final appId = data['app_id'];
       if (appId != null) {
         final name = _extractName(data);
-        final message = 'Created $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
+        final message =
+            'Created $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
         await _insertHistory(
           appId: appId,
           userId: getUserId(),
@@ -144,7 +162,8 @@ class ObjectRepository {
   }) async {
     if (data.isEmpty) throw Exception('Please input at least 1 field');
     try {
-      final setStatement = data.entries.map((e) => "'${e.key}' = '${e.value ?? ''}'").join(', ');
+      final setStatement =
+          data.entries.map((e) => "'${e.key}' = '${e.value ?? ''}'").join(', ');
       await db.execute(
         "UPDATE $tableName SET $setStatement WHERE id = ?",
         [objectId],
@@ -159,7 +178,8 @@ class ObjectRepository {
     required String objectId,
   }) async {
     try {
-      final item = await getObjectItem(tableName: tableName, objectId: objectId);
+      final item =
+          await getObjectItem(tableName: tableName, objectId: objectId);
       await db.execute(
         "DELETE FROM $tableName WHERE id = ?",
         [objectId],
@@ -168,7 +188,8 @@ class ObjectRepository {
       final appId = item['app_id'];
       if (appId != null) {
         final name = _extractName(item);
-        final message = 'Deleted $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
+        final message =
+            'Deleted $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
         await _insertHistory(
           appId: appId,
           userId: getUserId(),
@@ -191,7 +212,8 @@ class ObjectRepository {
       );
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -213,7 +235,8 @@ class ObjectRepository {
       );
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -235,7 +258,8 @@ class ObjectRepository {
       );
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -259,7 +283,8 @@ class ObjectRepository {
       );
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+              {}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -329,7 +354,8 @@ class ObjectRepository {
   }
 
   String _extractName(Map<String, dynamic> data) {
-    return (data['name'] ?? data['requirement'] ?? data['description'] ?? '').toString();
+    return (data['name'] ?? data['requirement'] ?? data['description'] ?? '')
+        .toString();
   }
 
   Future<void> _insertHistory({

--- a/apps/apprm/lib/features/home/pages/home_page.dart
+++ b/apps/apprm/lib/features/home/pages/home_page.dart
@@ -15,9 +15,18 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   final objectListData = [
-    (icon: PhosphorIconsFill.appWindow, title: 'Applications', route: '/applications'),
+    (
+      icon: PhosphorIconsFill.appWindow,
+      title: 'Applications',
+      route: '/applications'
+    ),
     (icon: PhosphorIconsFill.clock, title: 'Work Log', route: '/work_logs'),
-    (icon: PhosphorIconsFill.clockCounterClockwise, title: 'History', route: '/history')
+    (
+      icon: PhosphorIconsFill.clockCounterClockwise,
+      title: 'History',
+      route: '/history'
+    ),
+    (icon: PhosphorIconsFill.users, title: 'Admin', route: '/admin')
   ];
 
   @override

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -14,6 +14,7 @@ import 'features/home/pages/home_page.dart';
 import 'features/work_log/pages/work_log_listing_page.dart';
 import 'features/history/pages/history_listing_page.dart';
 import 'features/notification/pages/powersync_debug_page.dart';
+import 'features/admin/pages/admin_page.dart';
 import 'features/object/pages/external_object_detail_page.dart';
 import 'features/object/pages/external_object_listing_page.dart';
 import 'features/object/pages/object_adding_page.dart';
@@ -32,7 +33,8 @@ final rootRouter = GoRouter(
   navigatorKey: rootNavigatorKey,
   redirect: (context, state) {
     final bool onAuthPage = state.location.startsWith('/auth');
-    final isAuthenticated = Supabase.instance.client.auth.currentSession != null;
+    final isAuthenticated =
+        Supabase.instance.client.auth.currentSession != null;
 
     if (isAuthenticated && onAuthPage) {
       return HomeRoute().location;
@@ -180,6 +182,18 @@ class HistoryListingRoute extends GoRouteData {
   }
 }
 
+@TypedGoRoute<AdminRoute>(
+  path: '/admin',
+)
+class AdminRoute extends GoRouteData {
+  const AdminRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const AdminPage();
+  }
+}
+
 @TypedGoRoute<ObjectListingRoute>(
   path: '/app/:appId/internal/:objectType',
   routes: [
@@ -221,7 +235,8 @@ class ObjectAddingRoute extends GoRouteData {
 }
 
 class ObjectDetailRoute extends GoRouteData {
-  ObjectDetailRoute({required this.appId, required this.objectType, required this.objectId});
+  ObjectDetailRoute(
+      {required this.appId, required this.objectType, required this.objectId});
 
   final String appId;
   final String objectType;
@@ -234,7 +249,8 @@ class ObjectDetailRoute extends GoRouteData {
 }
 
 class ObjectUpdatingRoute extends GoRouteData {
-  ObjectUpdatingRoute({required this.appId, required this.objectType, required this.objectId});
+  ObjectUpdatingRoute(
+      {required this.appId, required this.objectType, required this.objectId});
 
   final String appId;
   final String objectType;

--- a/apps/apprm/lib/router.g.dart
+++ b/apps/apprm/lib/router.g.dart
@@ -14,6 +14,7 @@ List<RouteBase> get $appRoutes => [
       $applicationAddingRoute,
       $workLogListingRoute,
       $historyListingRoute,
+      $adminRoute,
       $objectListingRoute,
       $screenElementAddingRoute,
       $externalObjectListingRoute,
@@ -54,13 +55,15 @@ extension $AuthPageRouteExtension on AuthPageRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $SupabaseSignUpRouteExtension on SupabaseSignUpRoute {
-  static SupabaseSignUpRoute _fromState(GoRouterState state) => const SupabaseSignUpRoute();
+  static SupabaseSignUpRoute _fromState(GoRouterState state) =>
+      const SupabaseSignUpRoute();
 
   String get location => GoRouteData.$location(
         '/auth/sign-up',
@@ -70,13 +73,15 @@ extension $SupabaseSignUpRouteExtension on SupabaseSignUpRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $SupabaseLoginRouteExtension on SupabaseLoginRoute {
-  static SupabaseLoginRoute _fromState(GoRouterState state) => SupabaseLoginRoute(
+  static SupabaseLoginRoute _fromState(GoRouterState state) =>
+      SupabaseLoginRoute(
         email: state.queryParameters['email'],
       );
 
@@ -91,13 +96,15 @@ extension $SupabaseLoginRouteExtension on SupabaseLoginRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $AzureB2CLoginRouteExtension on AzureB2CLoginRoute {
-  static AzureB2CLoginRoute _fromState(GoRouterState state) => AzureB2CLoginRoute(
+  static AzureB2CLoginRoute _fromState(GoRouterState state) =>
+      AzureB2CLoginRoute(
         email: state.queryParameters['email'],
       );
 
@@ -112,7 +119,8 @@ extension $AzureB2CLoginRouteExtension on AzureB2CLoginRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -133,7 +141,8 @@ extension $Auth0LoginRouteExtension on Auth0LoginRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -154,7 +163,8 @@ extension $HomeRouteExtension on HomeRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -165,7 +175,8 @@ RouteBase get $applicationHomeRoute => GoRouteData.$route(
     );
 
 extension $ApplicationHomeRouteExtension on ApplicationHomeRoute {
-  static ApplicationHomeRoute _fromState(GoRouterState state) => ApplicationHomeRoute(
+  static ApplicationHomeRoute _fromState(GoRouterState state) =>
+      ApplicationHomeRoute(
         appId: state.pathParameters['appId']!,
       );
 
@@ -177,7 +188,8 @@ extension $ApplicationHomeRouteExtension on ApplicationHomeRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -188,7 +200,8 @@ RouteBase get $applicationListingRoute => GoRouteData.$route(
     );
 
 extension $ApplicationListingRouteExtension on ApplicationListingRoute {
-  static ApplicationListingRoute _fromState(GoRouterState state) => const ApplicationListingRoute();
+  static ApplicationListingRoute _fromState(GoRouterState state) =>
+      const ApplicationListingRoute();
 
   String get location => GoRouteData.$location(
         '/applications',
@@ -198,7 +211,8 @@ extension $ApplicationListingRouteExtension on ApplicationListingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -209,7 +223,8 @@ RouteBase get $applicationAddingRoute => GoRouteData.$route(
     );
 
 extension $ApplicationAddingRouteExtension on ApplicationAddingRoute {
-  static ApplicationAddingRoute _fromState(GoRouterState state) => ApplicationAddingRoute();
+  static ApplicationAddingRoute _fromState(GoRouterState state) =>
+      ApplicationAddingRoute();
 
   String get location => GoRouteData.$location(
         '/applications/add',
@@ -219,7 +234,8 @@ extension $ApplicationAddingRouteExtension on ApplicationAddingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -230,7 +246,8 @@ RouteBase get $workLogListingRoute => GoRouteData.$route(
     );
 
 extension $WorkLogListingRouteExtension on WorkLogListingRoute {
-  static WorkLogListingRoute _fromState(GoRouterState state) => const WorkLogListingRoute();
+  static WorkLogListingRoute _fromState(GoRouterState state) =>
+      const WorkLogListingRoute();
 
   String get location => GoRouteData.$location(
         '/work_logs',
@@ -240,7 +257,8 @@ extension $WorkLogListingRouteExtension on WorkLogListingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -251,7 +269,8 @@ RouteBase get $historyListingRoute => GoRouteData.$route(
     );
 
 extension $HistoryListingRouteExtension on HistoryListingRoute {
-  static HistoryListingRoute _fromState(GoRouterState state) => const HistoryListingRoute();
+  static HistoryListingRoute _fromState(GoRouterState state) =>
+      const HistoryListingRoute();
 
   String get location => GoRouteData.$location(
         '/history',
@@ -261,7 +280,30 @@ extension $HistoryListingRouteExtension on HistoryListingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $adminRoute => GoRouteData.$route(
+      path: '/admin',
+      factory: $AdminRouteExtension._fromState,
+    );
+
+extension $AdminRouteExtension on AdminRoute {
+  static AdminRoute _fromState(GoRouterState state) => const AdminRoute();
+
+  String get location => GoRouteData.$location(
+        '/admin',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -288,7 +330,8 @@ RouteBase get $objectListingRoute => GoRouteData.$route(
     );
 
 extension $ObjectListingRouteExtension on ObjectListingRoute {
-  static ObjectListingRoute _fromState(GoRouterState state) => ObjectListingRoute(
+  static ObjectListingRoute _fromState(GoRouterState state) =>
+      ObjectListingRoute(
         appId: state.pathParameters['appId']!,
         objectType: state.pathParameters['objectType']!,
       );
@@ -301,7 +344,8 @@ extension $ObjectListingRouteExtension on ObjectListingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -320,7 +364,8 @@ extension $ObjectAddingRouteExtension on ObjectAddingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -340,13 +385,15 @@ extension $ObjectDetailRouteExtension on ObjectDetailRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $ObjectUpdatingRouteExtension on ObjectUpdatingRoute {
-  static ObjectUpdatingRoute _fromState(GoRouterState state) => ObjectUpdatingRoute(
+  static ObjectUpdatingRoute _fromState(GoRouterState state) =>
+      ObjectUpdatingRoute(
         appId: state.pathParameters['appId']!,
         objectType: state.pathParameters['objectType']!,
         objectId: state.pathParameters['objectId']!,
@@ -360,7 +407,8 @@ extension $ObjectUpdatingRouteExtension on ObjectUpdatingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -371,7 +419,8 @@ RouteBase get $screenElementAddingRoute => GoRouteData.$route(
     );
 
 extension $ScreenElementAddingRouteExtension on ScreenElementAddingRoute {
-  static ScreenElementAddingRoute _fromState(GoRouterState state) => ScreenElementAddingRoute(
+  static ScreenElementAddingRoute _fromState(GoRouterState state) =>
+      ScreenElementAddingRoute(
         appId: state.pathParameters['appId']!,
         screenId: state.pathParameters['screenId']!,
       );
@@ -384,7 +433,8 @@ extension $ScreenElementAddingRouteExtension on ScreenElementAddingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -401,7 +451,8 @@ RouteBase get $externalObjectListingRoute => GoRouteData.$route(
     );
 
 extension $ExternalObjectListingRouteExtension on ExternalObjectListingRoute {
-  static ExternalObjectListingRoute _fromState(GoRouterState state) => ExternalObjectListingRoute(
+  static ExternalObjectListingRoute _fromState(GoRouterState state) =>
+      ExternalObjectListingRoute(
         externalObjectType: state.pathParameters['externalObjectType']!,
         objectType: state.queryParameters['object-type'],
         objectId: state.queryParameters['object-id'],
@@ -419,13 +470,15 @@ extension $ExternalObjectListingRouteExtension on ExternalObjectListingRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
 
 extension $ExternalObjectDetailRouteExtension on ExternalObjectDetailRoute {
-  static ExternalObjectDetailRoute _fromState(GoRouterState state) => ExternalObjectDetailRoute(
+  static ExternalObjectDetailRoute _fromState(GoRouterState state) =>
+      ExternalObjectDetailRoute(
         externalObjectType: state.pathParameters['externalObjectType']!,
         externalObjectId: state.pathParameters['externalObjectId']!,
         objectType: state.queryParameters['object-type'],
@@ -444,7 +497,8 @@ extension $ExternalObjectDetailRouteExtension on ExternalObjectDetailRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }
@@ -455,7 +509,8 @@ RouteBase get $notificationRoute => GoRouteData.$route(
     );
 
 extension $NotificationRouteExtension on NotificationRoute {
-  static NotificationRoute _fromState(GoRouterState state) => NotificationRoute();
+  static NotificationRoute _fromState(GoRouterState state) =>
+      NotificationRoute();
 
   String get location => GoRouteData.$location(
         '/notification',
@@ -465,7 +520,8 @@ extension $NotificationRouteExtension on NotificationRoute {
 
   Future<T?> push<T>(BuildContext context) => context.push<T>(location);
 
-  void pushReplacement(BuildContext context) => context.pushReplacement(location);
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
 
   void replace(BuildContext context) => context.replace(location);
 }


### PR DESCRIPTION
## Summary
- add `application_users` table to local schema
- show Admin on home page and create admin page to assign applications to users
- filter applications list to only show assignments for logged-in user
- wire new admin route into router

## Testing
- `flutter analyze`
- `flutter test` *(fails: Multiple exceptions detected)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a580db88321b61b7c49a985c5d2