### PR TITLE
Add role-based home logic

### DIFF
--- a/apps/apprm/lib/bootstrap/powersync.dart
+++ b/apps/apprm/lib/bootstrap/powersync.dart
@@ -142,6 +142,15 @@ String? getUserId() {
   return Supabase.instance.client.auth.currentSession?.user.id;
 }
 
+Future<bool> isAdminUser() async {
+  final userId = getUserId();
+  if (userId == null) return false;
+  final result =
+      await db.get("SELECT role FROM profile WHERE id=?", [userId]);
+  final role = result['role'] as String?;
+  return role == 'ADMIN';
+}
+
 Future<String> getDatabasePath() async {
   const dbFilename = 'powersync-apprm.db';
   final dir = await getApplicationSupportDirectory();

--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -25,6 +25,7 @@ Schema schema = Schema(
         Column.text('id'),
         Column.text('email'),
         Column.text('name'),
+        Column.text('role'),
       ],
       indexes: [
         Index('profile_list', [IndexedColumn('id')])

--- a/apps/apprm/lib/features/application/pages/application_listing_page.dart
+++ b/apps/apprm/lib/features/application/pages/application_listing_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 
+import '../../../bootstrap/powersync.dart';
+
 import '../../../constants/color.dart';
 import '../../common_object/entities/object_item.dart';
 import '../../common_object/mappers/application_mapper.dart';
@@ -19,6 +21,22 @@ class ApplicationListingPage extends StatefulWidget {
 
 class _ApplicationListingPageState extends State<ApplicationListingPage> {
   final listWrapperKey = GlobalKey<ObjectListWrapperState>();
+  bool _isAdmin = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRole();
+  }
+
+  Future<void> _loadRole() async {
+    final admin = await isAdminUser();
+    if (mounted) {
+      setState(() {
+        _isAdmin = admin;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -32,17 +50,27 @@ class _ApplicationListingPageState extends State<ApplicationListingPage> {
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 16),
-            child: IconButton.filled(
-              onPressed: () async {
-                await ApplicationAddingRoute().push(context);
-                listWrapperKey.currentState?.listKey.currentState?.onRefreshList();
-              },
-              icon: const Icon(PhosphorIconsBold.plus),
-              style: IconButton.styleFrom(
-                backgroundColor: AppColors.primaryColor,
-                foregroundColor: Colors.white,
-              ),
-            ),
+            child: _isAdmin
+                ? IconButton.filled(
+                    onPressed: () async {
+                      await ApplicationAddingRoute().push(context);
+                      listWrapperKey.currentState?.listKey.currentState?.onRefreshList();
+                    },
+                    icon: const Icon(PhosphorIconsBold.plus),
+                    style: IconButton.styleFrom(
+                      backgroundColor: AppColors.primaryColor,
+                      foregroundColor: Colors.white,
+                    ),
+                  )
+                : IconButton(
+                    onPressed: () async {
+                      await logout();
+                      if (context.mounted) {
+                        const AuthPageRoute().pushReplacement(context);
+                      }
+                    },
+                    icon: const Icon(PhosphorIconsBold.signOut),
+                  ),
           )
         ],
       ),

--- a/apps/apprm/lib/features/home/pages/root_home_page.dart
+++ b/apps/apprm/lib/features/home/pages/root_home_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../../bootstrap/powersync.dart';
+import '../../application/pages/application_listing_page.dart';
+import 'home_page.dart';
+
+class RootHomePage extends StatefulWidget {
+  const RootHomePage({super.key});
+
+  @override
+  State<RootHomePage> createState() => _RootHomePageState();
+}
+
+class _RootHomePageState extends State<RootHomePage> {
+  late Future<bool> _checkAdmin;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkAdmin = isAdminUser();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: _checkAdmin,
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final admin = snapshot.data ?? false;
+        return admin ? const HomePage() : const ApplicationListingPage();
+      },
+    );
+  }
+}

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -10,7 +10,7 @@ import 'features/auth/pages/supabase_signup_page.dart';
 import 'features/application/pages/application_listing_page.dart';
 import 'features/application/pages/application_home_page.dart';
 import 'features/application/pages/application_adding_page.dart';
-import 'features/home/pages/home_page.dart';
+import 'features/home/pages/root_home_page.dart';
 import 'features/work_log/pages/work_log_listing_page.dart';
 import 'features/history/pages/history_listing_page.dart';
 import 'features/notification/pages/powersync_debug_page.dart';
@@ -118,7 +118,7 @@ class Auth0LoginRoute extends GoRouteData {
 class HomeRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
-    return const HomePage();
+    return const RootHomePage();
   }
 }
 


### PR DESCRIPTION
## Summary
- add `role` column in profile schema
- detect admin users with `isAdminUser`
- choose root screen based on role in new `RootHomePage`
- show add/logout buttons conditionally in `ApplicationListingPage`
- route `/` to new role-aware home page

## Testing
- `flutter analyze`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_684d73b855208321a7248787925d908d