### PR TITLE
Fix data_fields encryption display

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -6,6 +6,7 @@ import '../../../utils/crypt.dart';
 
 const _encryptedNameDescriptionTables = {
   'data_objects',
+  'data_fields',
   'screens',
   'screen_functions',
   'user_stories',


### PR DESCRIPTION
## Summary
- decrypt `data_fields` when fetching objects

## Testing
- `flutter test test/widget_test.dart -d none` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_684dd0b6fd24832197ed764393f82ac7