### PR TITLE
Fix data_fields encryption display

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -6,6 +6,7 @@ import '../../../utils/crypt.dart';
 
 const _encryptedNameDescriptionTables = {
   'data_objects',
+  'data_fields',
   'screens',
   'screen_functions',
   'user_stories',
@@ -446,6 +447,13 @@ class ObjectRepository {
       newData['description'] =
           executeEncrypt(newData['description'].toString(), secret);
     }
+    if (newData['type'] != null) {
+      newData['type'] = executeEncrypt(newData['type'].toString(), secret);
+    }
+    if (newData['default_value'] != null) {
+      newData['default_value'] =
+          executeEncrypt(newData['default_value'].toString(), secret);
+    }
     return newData;
   }
 
@@ -482,6 +490,13 @@ class ObjectRepository {
     if (newData['description'] != null) {
       newData['description'] =
           executeDecrypt(newData['description'].toString(), secret);
+    }
+    if (newData['type'] != null) {
+      newData['type'] = executeDecrypt(newData['type'].toString(), secret);
+    }
+    if (newData['default_value'] != null) {
+      newData['default_value'] =
+          executeDecrypt(newData['default_value'].toString(), secret);
     }
     return newData;
   }


### PR DESCRIPTION
## Summary
- decrypt `data_fields` when fetching objects
- encrypt/decrypt `type` and `default_value` for data fields

## Testing
- `flutter test test/widget_test.dart -d none` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_684dd0b6fd24832197ed764393f82ac7