### PR TITLE
Separate screen vs element photo storage

### DIFF
--- a/apps/apprm/lib/features/screens/widgets/element_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/element_photo_list.dart
@@ -22,7 +22,8 @@ class ElementPhotoList extends ConsumerStatefulWidget {
   final String elementId;
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _ElementPhotoListState();
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _ElementPhotoListState();
 }
 
 class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
@@ -52,7 +53,7 @@ class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
 
     final bytes = await file.readAsBytes();
     final photoId = const Uuid().v4();
-    final filename = '$photoId.jpg';
+    final filename = 'elements/$photoId.jpg';
     final localUri = await attachmentQueue.getLocalUri(filename);
 
     final destDir = Directory(localUri).parent;
@@ -61,7 +62,7 @@ class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
     }
 
     await attachmentQueue.localStorage.copyFile(file.path, localUri);
-    await attachmentQueue.saveFile(photoId, bytes.length);
+    await attachmentQueue.saveFile(photoId, bytes.length, folder: 'elements');
 
     await _createMutation.mutate(
       CreateObjectUseCaseParams(
@@ -78,7 +79,7 @@ class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
   }
 
   Future<void> _deletePhoto(Map<String, dynamic> item) async {
-    await attachmentQueue.deleteFile(item['photo_id']);
+    await attachmentQueue.deleteFile(item['photo_id'], folder: 'elements');
     await _deleteMutation.mutate(
       DeleteObjectItemUseCaseParams(
         objectType: 'element_photos',
@@ -110,7 +111,7 @@ class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
 
   Future<void> _openPhotoDetail(Map<String, dynamic> item) async {
     final localPath =
-        await attachmentQueue.getLocalUri('${item['photo_id']}.jpg');
+        await attachmentQueue.getLocalUri('elements/${item['photo_id']}.jpg');
     if (!mounted) return;
     await showDialog(
       context: context,
@@ -225,7 +226,7 @@ class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
                       children: list.map((e) {
                         return FutureBuilder<String>(
                           future: attachmentQueue
-                              .getLocalUri('${e['photo_id']}.jpg'),
+                              .getLocalUri('elements/${e['photo_id']}.jpg'),
                           builder: (context, snapshot) {
                             if (!snapshot.hasData) {
                               return const SizedBox(

--- a/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
@@ -54,7 +54,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
 
     final bytes = await file.readAsBytes();
     final photoId = const Uuid().v4();
-    final filename = '$photoId.jpg';
+    final filename = 'screens/$photoId.jpg';
     final localUri = await attachmentQueue.getLocalUri(filename);
 
     // Ensure the directory exists
@@ -64,7 +64,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
     }
 
     await attachmentQueue.localStorage.copyFile(file.path, localUri);
-    await attachmentQueue.saveFile(photoId, bytes.length);
+    await attachmentQueue.saveFile(photoId, bytes.length, folder: 'screens');
 
     await _createMutation.mutate(
       CreateObjectUseCaseParams(
@@ -82,7 +82,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
   }
 
   Future<void> _deletePhoto(Map<String, dynamic> item) async {
-    await attachmentQueue.deleteFile(item['photo_id']);
+    await attachmentQueue.deleteFile(item['photo_id'], folder: 'screens');
     await _deleteMutation.mutate(
       DeleteObjectItemUseCaseParams(
         objectType: 'screen_photos',
@@ -114,7 +114,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
 
   Future<void> _openPhotoDetail(Map<String, dynamic> item) async {
     final localPath =
-        await attachmentQueue.getLocalUri('${item['photo_id']}.jpg');
+        await attachmentQueue.getLocalUri('screens/${item['photo_id']}.jpg');
     if (!mounted) return;
     await showDialog(
       context: context,
@@ -229,7 +229,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
                       children: list.map((e) {
                         return FutureBuilder<String>(
                           future: attachmentQueue
-                              .getLocalUri('${e['photo_id']}.jpg'),
+                              .getLocalUri('screens/${e['photo_id']}.jpg'),
                           builder: (context, snapshot) {
                             if (!snapshot.hasData) {
                               return const SizedBox(


### PR DESCRIPTION
## Summary
- support specifying folders for attachments
- store screen photos in `screens/` and element photos in `elements/`
- download photos from correct folders
- watch both photo tables for remote downloads

## Testing
- `dart analyze`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_684de92e1bb48321baee2fcf0c018126