### PR TITLE
Decrypt history log entries

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -181,7 +181,17 @@ class ObjectRepository {
 
       final appId = data['app_id'];
       if (appId != null) {
-        final name = _extractName(data);
+        var name = _extractName(data);
+        if (name.isNotEmpty) {
+          final secret = await _getAppSecret(appId);
+          if (secret != null) {
+            try {
+              name = executeDecrypt(name, secret);
+            } catch (_) {
+              // ignore decrypt errors
+            }
+          }
+        }
         final message =
             'Created $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
         await _insertHistory(


### PR DESCRIPTION
## Summary
- decrypt object names before writing history entries

## Testing
- `flutter analyze`
- `flutter test` *(fails: Multiple exceptions during widget test)*

------
https://chatgpt.com/codex/tasks/task_e_684e2e73f8e88321835acba4a691e875