### PR TITLE
Add user story steps

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
@@ -17,6 +17,8 @@ import 'screen_function.dart';
 import 'ui_element.dart';
 import 'story.dart';
 import 'user_story.dart';
+import 'user_story_step.dart';
+import 'user_story_step_action.dart';
 import 'serialize_plugins/custom_8601_date_time_plugin.dart';
 import 'requirement.dart';
 
@@ -38,6 +40,8 @@ const List<Type> _registeredTypes = [
   DataLink,
   Story,
   UserStory,
+  UserStoryStep,
+  UserStoryStepAction,
 ];
 
 /// Addition builder factories, if needed.

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
@@ -20,7 +20,9 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(ScreenFunction.serializer)
       ..add(Story.serializer)
       ..add(UiElement.serializer)
-      ..add(UserStory.serializer))
+      ..add(UserStory.serializer)
+      ..add(UserStoryStep.serializer)
+      ..add(UserStoryStepAction.serializer))
     .build();
 
 // ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step.dart
@@ -1,0 +1,36 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'user_story_step.g.dart';
+
+abstract class UserStoryStep implements Built<UserStoryStep, UserStoryStepBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  @BuiltValueField(wireName: 'story_id')
+  String? get storyId;
+
+  int? get rank;
+
+  String? get name;
+
+  String? get description;
+
+  UserStoryStep._();
+  factory UserStoryStep([void Function(UserStoryStepBuilder) updates]) = _$UserStoryStep;
+
+  static Serializer<UserStoryStep> get serializer => _$userStoryStepSerializer;
+
+  factory UserStoryStep.fromJson(Map<String, dynamic> json) =>
+      serializers.deserializeWith<UserStoryStep>(serializer, json)!;
+
+  Map<String, dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step.g.dart
@@ -1,0 +1,274 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_story_step.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<UserStoryStep> _$userStoryStepSerializer =
+    new _$UserStoryStepSerializer();
+
+class _$UserStoryStepSerializer implements StructuredSerializer<UserStoryStep> {
+  @override
+  final Iterable<Type> types = const [UserStoryStep, _$UserStoryStep];
+  @override
+  final String wireName = 'UserStoryStep';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UserStoryStep object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.storyId;
+    if (value != null) {
+      result
+        ..add('story_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.rank;
+    if (value != null) {
+      result
+        ..add('rank')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    value = object.name;
+    if (value != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  UserStoryStep deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new UserStoryStepBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'story_id':
+          result.storyId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'rank':
+          result.rank = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserStoryStep extends UserStoryStep {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? storyId;
+  @override
+  final int? rank;
+  @override
+  final String? name;
+  @override
+  final String? description;
+
+  factory _$UserStoryStep([void Function(UserStoryStepBuilder)? updates]) =>
+      (new UserStoryStepBuilder()..update(updates))._build();
+
+  _$UserStoryStep._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.storyId,
+      this.rank,
+      this.name,
+      this.description})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'UserStoryStep', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        createdAt, r'UserStoryStep', 'createdAt');
+  }
+
+  @override
+  UserStoryStep rebuild(void Function(UserStoryStepBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStoryStepBuilder toBuilder() => new UserStoryStepBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStoryStep &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        storyId == other.storyId &&
+        rank == other.rank &&
+        name == other.name &&
+        description == other.description;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, storyId.hashCode);
+    _$hash = $jc(_$hash, rank.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStoryStep')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('storyId', storyId)
+          ..add('rank', rank)
+          ..add('name', name)
+          ..add('description', description))
+        .toString();
+  }
+}
+
+class UserStoryStepBuilder
+    implements Builder<UserStoryStep, UserStoryStepBuilder> {
+  _$UserStoryStep? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _storyId;
+  String? get storyId => _$this._storyId;
+  set storyId(String? storyId) => _$this._storyId = storyId;
+
+  int? _rank;
+  int? get rank => _$this._rank;
+  set rank(int? rank) => _$this._rank = rank;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  UserStoryStepBuilder();
+
+  UserStoryStepBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _storyId = $v.storyId;
+      _rank = $v.rank;
+      _name = $v.name;
+      _description = $v.description;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UserStoryStep other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStoryStep;
+  }
+
+  @override
+  void update(void Function(UserStoryStepBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStoryStep build() => _build();
+
+  _$UserStoryStep _build() {
+    final _$result = _$v ??
+        new _$UserStoryStep._(
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, r'UserStoryStep', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'UserStoryStep', 'createdAt'),
+            updatedAt: updatedAt,
+            storyId: storyId,
+            rank: rank,
+            name: name,
+            description: description);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.dart
@@ -1,0 +1,41 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'user_story_step_action.g.dart';
+
+abstract class UserStoryStepAction
+    implements Built<UserStoryStepAction, UserStoryStepActionBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  @BuiltValueField(wireName: 'step_id')
+  String? get stepId;
+
+  @BuiltValueField(wireName: 'target_id')
+  String? get targetId;
+
+  @BuiltValueField(wireName: 'target_type')
+  String? get targetType;
+
+  String? get description;
+
+  int? get rank;
+
+  UserStoryStepAction._();
+  factory UserStoryStepAction([void Function(UserStoryStepActionBuilder) updates]) = _$UserStoryStepAction;
+
+  static Serializer<UserStoryStepAction> get serializer => _$userStoryStepActionSerializer;
+
+  factory UserStoryStepAction.fromJson(Map<String, dynamic> json) =>
+      serializers.deserializeWith<UserStoryStepAction>(serializer, json)!;
+
+  Map<String, dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String, dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.g.dart
@@ -1,0 +1,305 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_story_step_action.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<UserStoryStepAction> _$userStoryStepActionSerializer =
+    new _$UserStoryStepActionSerializer();
+
+class _$UserStoryStepActionSerializer
+    implements StructuredSerializer<UserStoryStepAction> {
+  @override
+  final Iterable<Type> types = const [
+    UserStoryStepAction,
+    _$UserStoryStepAction
+  ];
+  @override
+  final String wireName = 'UserStoryStepAction';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, UserStoryStepAction object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.stepId;
+    if (value != null) {
+      result
+        ..add('step_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.targetId;
+    if (value != null) {
+      result
+        ..add('target_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.targetType;
+    if (value != null) {
+      result
+        ..add('target_type')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.rank;
+    if (value != null) {
+      result
+        ..add('rank')
+        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  @override
+  UserStoryStepAction deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new UserStoryStepActionBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'step_id':
+          result.stepId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'target_id':
+          result.targetId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'target_type':
+          result.targetType = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'rank':
+          result.rank = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserStoryStepAction extends UserStoryStepAction {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? stepId;
+  @override
+  final String? targetId;
+  @override
+  final String? targetType;
+  @override
+  final String? description;
+  @override
+  final int? rank;
+
+  factory _$UserStoryStepAction(
+          [void Function(UserStoryStepActionBuilder)? updates]) =>
+      (new UserStoryStepActionBuilder()..update(updates))._build();
+
+  _$UserStoryStepAction._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.stepId,
+      this.targetId,
+      this.targetType,
+      this.description,
+      this.rank})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'UserStoryStepAction', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        createdAt, r'UserStoryStepAction', 'createdAt');
+  }
+
+  @override
+  UserStoryStepAction rebuild(
+          void Function(UserStoryStepActionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStoryStepActionBuilder toBuilder() =>
+      new UserStoryStepActionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStoryStepAction &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        stepId == other.stepId &&
+        targetId == other.targetId &&
+        targetType == other.targetType &&
+        description == other.description &&
+        rank == other.rank;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, stepId.hashCode);
+    _$hash = $jc(_$hash, targetId.hashCode);
+    _$hash = $jc(_$hash, targetType.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, rank.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStoryStepAction')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('stepId', stepId)
+          ..add('targetId', targetId)
+          ..add('targetType', targetType)
+          ..add('description', description)
+          ..add('rank', rank))
+        .toString();
+  }
+}
+
+class UserStoryStepActionBuilder
+    implements Builder<UserStoryStepAction, UserStoryStepActionBuilder> {
+  _$UserStoryStepAction? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _stepId;
+  String? get stepId => _$this._stepId;
+  set stepId(String? stepId) => _$this._stepId = stepId;
+
+  String? _targetId;
+  String? get targetId => _$this._targetId;
+  set targetId(String? targetId) => _$this._targetId = targetId;
+
+  String? _targetType;
+  String? get targetType => _$this._targetType;
+  set targetType(String? targetType) => _$this._targetType = targetType;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  int? _rank;
+  int? get rank => _$this._rank;
+  set rank(int? rank) => _$this._rank = rank;
+
+  UserStoryStepActionBuilder();
+
+  UserStoryStepActionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _stepId = $v.stepId;
+      _targetId = $v.targetId;
+      _targetType = $v.targetType;
+      _description = $v.description;
+      _rank = $v.rank;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UserStoryStepAction other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStoryStepAction;
+  }
+
+  @override
+  void update(void Function(UserStoryStepActionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStoryStepAction build() => _build();
+
+  _$UserStoryStepAction _build() {
+    final _$result = _$v ??
+        new _$UserStoryStepAction._(
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, r'UserStoryStepAction', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'UserStoryStepAction', 'createdAt'),
+            updatedAt: updatedAt,
+            stepId: stepId,
+            targetId: targetId,
+            targetType: targetType,
+            description: description,
+            rank: rank);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/mappers/user_story_step_action_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/user_story_step_action_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/user_story_step_action.dart';
+
+class UserStoryStepActionToObjectItemMapper {
+  static ObjectItem fromModel(UserStoryStepAction item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.targetType ?? '',
+      subTitle: item.description ?? '',
+      sortFields: [
+        (key: 'rank', label: 'Rank'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(UserStoryStepAction.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/mappers/user_story_step_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/user_story_step_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/user_story_step.dart';
+
+class UserStoryStepToObjectItemMapper {
+  static ObjectItem fromModel(UserStoryStep item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.name ?? '',
+      subTitle: item.description ?? '',
+      sortFields: [
+        (key: 'rank', label: 'Rank'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(UserStoryStep.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -6,6 +6,8 @@ import 'package:apprm/features/screens/widgets/data_link_list.dart';
 import 'package:apprm/features/screens/widgets/element_list.dart';
 import 'package:apprm/features/screens/widgets/element_photo_list.dart';
 import 'package:apprm/features/screens/widgets/navigation_list.dart';
+import 'package:apprm/features/user_story/widgets/step_list.dart';
+import 'package:apprm/features/user_story/widgets/step_action_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -70,6 +72,10 @@ class ObjectDetailCard extends ConsumerWidget {
               DataFieldList(
                 dataObjectId: objectId,
               ),
+            if (objectType == 'user_stories')
+              StepList(
+                storyId: objectId,
+              ),
             if (objectType == 'screens') ...[
               ScreenPhotoList(
                 appId: appId,
@@ -104,6 +110,11 @@ class ObjectDetailCard extends ConsumerWidget {
                 objectId: objectId,
                 objectType: 'element',
                 screenId: screenId,
+              ),
+            if (objectType == 'user_story_steps')
+              StepActionList(
+                appId: appId,
+                stepId: objectId,
               ),
           ],
         ),

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -208,6 +208,72 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         ),
       ],
     ),
+    'user_story_steps': (
+      label: 'step',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'story_id',
+          label: 'Story ID',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
+    'user_story_step_actions': (
+      label: 'step action',
+      inputFields: [
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'step_id',
+          label: 'Step ID',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'target_id',
+          label: 'Target',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'target_type',
+          label: 'Target Type',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: ['element', 'screen_function'],
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'work_logs': (
       label: 'work log',
       inputFields: [

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -15,6 +15,8 @@ import '../../common_object/mappers/data_field_mapper.dart';
 import '../../common_object/mappers/screen_function_mapper.dart';
 import '../../common_object/mappers/ui_element_mapper.dart';
 import '../../common_object/mappers/work_log_mapper.dart';
+import '../../common_object/mappers/user_story_step_mapper.dart';
+import '../../common_object/mappers/user_story_step_action_mapper.dart';
 import '../../common_object/widgets/detail/object_detail_wrapper.dart';
 
 class ObjectDetailPage extends StatefulWidget {
@@ -83,6 +85,20 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       dataMapperFn: UserStoryToObjectItemMapper.fromJson,
       displayFields: [
         (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+      ],
+    ),
+    'user_story_steps': (
+      dataMapperFn: UserStoryStepToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+      ],
+    ),
+    'user_story_step_actions': (
+      dataMapperFn: UserStoryStepActionToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'target_type', label: 'Target Type'),
         (key: 'description', label: 'Description'),
       ],
     ),

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -259,6 +259,40 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'user_story_steps': (
+      label: 'step',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
+    'user_story_step_actions': (
+      label: 'step action',
+      inputFields: [
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'work_logs': (
       label: 'work log',
       inputFields: [

--- a/apps/apprm/lib/features/user_story/widgets/step_action_list.dart
+++ b/apps/apprm/lib/features/user_story/widgets/step_action_list.dart
@@ -1,0 +1,216 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../constants/color.dart';
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/create_object_usecase.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+import '../../screens/widgets/element_selection.dart';
+import '../../screens/widgets/function_selection.dart';
+import '../../screens/widgets/screen_selection.dart';
+
+class StepActionList extends ConsumerStatefulWidget {
+  const StepActionList({super.key, required this.appId, required this.stepId});
+
+  final String appId;
+  final String stepId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _StepActionListState();
+}
+
+class _StepActionListState extends ConsumerState<StepActionList> {
+  final _createMutation = Mutation<void, CreateObjectUseCaseParams>(
+    queryFn: (params) => CreateObjectUseCase(
+      objectRepository: ObjectRepository(),
+    ).execute(params),
+  );
+
+  void _refresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['user_story_step_actions', 'list', widget.stepId]
+    ]);
+  }
+
+  Future<void> _addAction() async {
+    final option = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Text('Add Action'),
+          children: [
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop('element'),
+              child: const Text('Element'),
+            ),
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop('function'),
+              child: const Text('Function'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (option == null) return;
+
+    final selectedScreen =
+        await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+      context: context,
+      builder: (_) => ScreenSelection(appId: widget.appId),
+    );
+    if (selectedScreen == null) return;
+
+    Map<String, dynamic>? selected;
+    if (option == 'element') {
+      selected = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+        context: context,
+        builder: (_) => ElementSelection(screenId: selectedScreen['id']),
+      );
+    } else {
+      selected = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+        context: context,
+        builder: (_) => FunctionSelection(screenId: selectedScreen['id']),
+      );
+    }
+    if (selected == null) return;
+
+    final descController = TextEditingController();
+    final desc = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Description'),
+          content: TextField(
+            controller: descController,
+            decoration: const InputDecoration(border: OutlineInputBorder()),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(descController.text),
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
+
+    await _createMutation.mutate(
+      CreateObjectUseCaseParams(
+        objectType: 'user_story_step_actions',
+        data: {
+          'step_id': widget.stepId,
+          'target_id': selected['id'],
+          'target_type': option == 'element' ? 'element' : 'screen_function',
+          'description': desc,
+        },
+      ),
+    );
+
+    _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = widget.appId;
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Actions',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'user_story_step_actions',
+                  'list',
+                  widget.stepId,
+                ],
+                queryFn: () async {
+                  return await GetObjectListUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetObjectListUseCaseParams(
+                      objectType: 'user_story_step_actions',
+                      sortValues: const {},
+                      filterValues: {'step_id': widget.stepId},
+                      searchFields: const ['description'],
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: Duration(seconds: 1),
+                  refetchDuration: Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              final list = state.data ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (list.isEmpty)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...list.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'user_story_step_actions',
+                            objectId: e['id'],
+                          ).push(context);
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['description'] ?? e['target_id'],
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: _addAction,
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/user_story/widgets/step_list.dart
+++ b/apps/apprm/lib/features/user_story/widgets/step_list.dart
@@ -1,0 +1,133 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../constants/color.dart';
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+
+class StepList extends ConsumerStatefulWidget {
+  const StepList({super.key, required this.storyId});
+
+  final String storyId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _StepListState();
+}
+
+class _StepListState extends ConsumerState<StepList> {
+  void onRefresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['user_story_steps', 'list', widget.storyId]
+    ]);
+  }
+
+  Future<void> _addStep(String appId) async {
+    await context.push(
+      '/app/$appId/internal/user_story_steps/add?story_id=${widget.storyId}',
+    );
+    onRefresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Steps',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'user_story_steps',
+                  'list',
+                  widget.storyId,
+                ],
+                queryFn: () async {
+                  return await GetObjectListUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetObjectListUseCaseParams(
+                      objectType: 'user_story_steps',
+                      sortValues: const {},
+                      filterValues: {'story_id': widget.storyId},
+                      searchFields: const ['name'],
+                    ),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: Duration(seconds: 1),
+                  refetchDuration: Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (state.data?.isEmpty ?? true)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...state.data!.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final result = await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'user_story_steps',
+                            objectId: e['id'],
+                          ).push(context);
+                          if (result == true) {
+                            onRefresh();
+                          }
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['name'] ?? '--',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: () => _addStep(appIdParam),
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add user story step and step action models
- enable steps and step actions in serializers
- add mappers for new models
- allow creating steps and actions
- show steps under user story detail and actions under step detail

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6851902c451483219f356bf115861277