### PR TITLE
Add story steps and actions

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -320,6 +320,37 @@ Schema schema = Schema(
       ],
     ),
     const Table(
+      'user_story_steps',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('story_id'),
+        Column.text('rank'),
+        Column.text('name'),
+        Column.text('description'),
+      ],
+      indexes: [
+        Index('user_story_steps_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
+      'user_story_step_actions',
+      [
+        Column.text('id'),
+        Column.text('created_at'),
+        Column.text('updated_at'),
+        Column.text('step_id'),
+        Column.text('target_id'),
+        Column.text('target_type'),
+        Column.text('description'),
+        Column.text('rank'),
+      ],
+      indexes: [
+        Index('user_story_step_actions_list', [IndexedColumn('id')])
+      ],
+    ),
+    const Table(
       'work_logs',
       [
         Column.text('id'),

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.dart
@@ -17,6 +17,8 @@ import 'screen_function.dart';
 import 'ui_element.dart';
 import 'story.dart';
 import 'user_story.dart';
+import 'user_story_step.dart';
+import 'user_story_step_action.dart';
 import 'serialize_plugins/custom_8601_date_time_plugin.dart';
 import 'requirement.dart';
 
@@ -38,6 +40,8 @@ const List<Type> _registeredTypes = [
   DataLink,
   Story,
   UserStory,
+  UserStoryStep,
+  UserStoryStepAction,
 ];
 
 /// Addition builder factories, if needed.

--- a/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/serializers.g.dart
@@ -20,7 +20,9 @@ Serializers _$serializers = (new Serializers().toBuilder()
       ..add(ScreenFunction.serializer)
       ..add(Story.serializer)
       ..add(UiElement.serializer)
-      ..add(UserStory.serializer))
+      ..add(UserStory.serializer)
+      ..add(UserStoryStep.serializer)
+      ..add(UserStoryStepAction.serializer))
     .build();
 
 // ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step.dart
@@ -1,0 +1,36 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'user_story_step.g.dart';
+
+abstract class UserStoryStep implements Built<UserStoryStep, UserStoryStepBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  @BuiltValueField(wireName: 'story_id')
+  String? get storyId;
+
+  String? get rank;
+
+  String? get name;
+
+  String? get description;
+
+  UserStoryStep._();
+  factory UserStoryStep([void Function(UserStoryStepBuilder) updates]) = _$UserStoryStep;
+
+  static Serializer<UserStoryStep> get serializer => _$userStoryStepSerializer;
+
+  factory UserStoryStep.fromJson(Map<String,dynamic> json) =>
+      serializers.deserializeWith<UserStoryStep>(serializer, json)!;
+
+  Map<String,dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String,dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step.g.dart
@@ -1,0 +1,275 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_story_step.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<UserStoryStep> _$userStoryStepSerializer =
+    new _$UserStoryStepSerializer();
+
+class _$UserStoryStepSerializer implements StructuredSerializer<UserStoryStep> {
+  @override
+  final Iterable<Type> types = const [UserStoryStep, _$UserStoryStep];
+  @override
+  final String wireName = 'UserStoryStep';
+
+  @override
+  Iterable<Object?> serialize(Serializers serializers, UserStoryStep object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.storyId;
+    if (value != null) {
+      result
+        ..add('story_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.rank;
+    if (value != null) {
+      result
+        ..add('rank')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.name;
+    if (value != null) {
+      result
+        ..add('name')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  UserStoryStep deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new UserStoryStepBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'story_id':
+          result.storyId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'rank':
+          result.rank = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserStoryStep extends UserStoryStep {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? storyId;
+  @override
+  final String? rank;
+  @override
+  final String? name;
+  @override
+  final String? description;
+
+  factory _$UserStoryStep([void Function(UserStoryStepBuilder)? updates]) =>
+      (new UserStoryStepBuilder()..update(updates))._build();
+
+  _$UserStoryStep._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.storyId,
+      this.rank,
+      this.name,
+      this.description})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'UserStoryStep', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        createdAt, r'UserStoryStep', 'createdAt');
+  }
+
+  @override
+  UserStoryStep rebuild(void Function(UserStoryStepBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStoryStepBuilder toBuilder() => new UserStoryStepBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStoryStep &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        storyId == other.storyId &&
+        rank == other.rank &&
+        name == other.name &&
+        description == other.description;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, storyId.hashCode);
+    _$hash = $jc(_$hash, rank.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStoryStep')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('storyId', storyId)
+          ..add('rank', rank)
+          ..add('name', name)
+          ..add('description', description))
+        .toString();
+  }
+}
+
+class UserStoryStepBuilder
+    implements Builder<UserStoryStep, UserStoryStepBuilder> {
+  _$UserStoryStep? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _storyId;
+  String? get storyId => _$this._storyId;
+  set storyId(String? storyId) => _$this._storyId = storyId;
+
+  String? _rank;
+  String? get rank => _$this._rank;
+  set rank(String? rank) => _$this._rank = rank;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  UserStoryStepBuilder();
+
+  UserStoryStepBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _storyId = $v.storyId;
+      _rank = $v.rank;
+      _name = $v.name;
+      _description = $v.description;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UserStoryStep other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStoryStep;
+  }
+
+  @override
+  void update(void Function(UserStoryStepBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStoryStep build() => _build();
+
+  _$UserStoryStep _build() {
+    final _$result = _$v ??
+        new _$UserStoryStep._(
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, r'UserStoryStep', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'UserStoryStep', 'createdAt'),
+            updatedAt: updatedAt,
+            storyId: storyId,
+            rank: rank,
+            name: name,
+            description: description);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.dart
@@ -1,0 +1,40 @@
+import 'package:built_value/built_value.dart';
+import 'package:built_value/serializer.dart';
+
+import 'serializers.dart';
+
+part 'user_story_step_action.g.dart';
+
+abstract class UserStoryStepAction implements Built<UserStoryStepAction, UserStoryStepActionBuilder> {
+  String get id;
+
+  @BuiltValueField(wireName: 'created_at')
+  DateTime get createdAt;
+
+  @BuiltValueField(wireName: 'updated_at')
+  DateTime? get updatedAt;
+
+  @BuiltValueField(wireName: 'step_id')
+  String? get stepId;
+
+  @BuiltValueField(wireName: 'target_id')
+  String? get targetId;
+
+  @BuiltValueField(wireName: 'target_type')
+  String? get targetType;
+
+  String? get description;
+
+  String? get rank;
+
+  UserStoryStepAction._();
+  factory UserStoryStepAction([void Function(UserStoryStepActionBuilder) updates]) = _$UserStoryStepAction;
+
+  static Serializer<UserStoryStepAction> get serializer => _$userStoryStepActionSerializer;
+
+  factory UserStoryStepAction.fromJson(Map<String,dynamic> json) =>
+      serializers.deserializeWith<UserStoryStepAction>(serializer, json)!;
+
+  Map<String,dynamic> toJson() =>
+      serializers.serializeWith(serializer, this)! as Map<String,dynamic>;
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/user_story_step_action.g.dart
@@ -1,0 +1,306 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_story_step_action.dart';
+
+// **************************************************************************
+// BuiltValueGenerator
+// **************************************************************************
+
+Serializer<UserStoryStepAction> _$userStoryStepActionSerializer =
+    new _$UserStoryStepActionSerializer();
+
+class _$UserStoryStepActionSerializer
+    implements StructuredSerializer<UserStoryStepAction> {
+  @override
+  final Iterable<Type> types = const [
+    UserStoryStepAction,
+    _$UserStoryStepAction
+  ];
+  @override
+  final String wireName = 'UserStoryStepAction';
+
+  @override
+  Iterable<Object?> serialize(
+      Serializers serializers, UserStoryStepAction object,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = <Object?>[
+      'id',
+      serializers.serialize(object.id, specifiedType: const FullType(String)),
+      'created_at',
+      serializers.serialize(object.createdAt,
+          specifiedType: const FullType(DateTime)),
+    ];
+    Object? value;
+    value = object.updatedAt;
+    if (value != null) {
+      result
+        ..add('updated_at')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(DateTime)));
+    }
+    value = object.stepId;
+    if (value != null) {
+      result
+        ..add('step_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.targetId;
+    if (value != null) {
+      result
+        ..add('target_id')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.targetType;
+    if (value != null) {
+      result
+        ..add('target_type')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.description;
+    if (value != null) {
+      result
+        ..add('description')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    value = object.rank;
+    if (value != null) {
+      result
+        ..add('rank')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  @override
+  UserStoryStepAction deserialize(
+      Serializers serializers, Iterable<Object?> serialized,
+      {FullType specifiedType = FullType.unspecified}) {
+    final result = new UserStoryStepActionBuilder();
+
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current! as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          result.id = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
+          break;
+        case 'created_at':
+          result.createdAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime))! as DateTime;
+          break;
+        case 'updated_at':
+          result.updatedAt = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime?;
+          break;
+        case 'step_id':
+          result.stepId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'target_id':
+          result.targetId = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'target_type':
+          result.targetType = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'description':
+          result.description = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+        case 'rank':
+          result.rank = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
+      }
+    }
+
+    return result.build();
+  }
+}
+
+class _$UserStoryStepAction extends UserStoryStepAction {
+  @override
+  final String id;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime? updatedAt;
+  @override
+  final String? stepId;
+  @override
+  final String? targetId;
+  @override
+  final String? targetType;
+  @override
+  final String? description;
+  @override
+  final String? rank;
+
+  factory _$UserStoryStepAction(
+          [void Function(UserStoryStepActionBuilder)? updates]) =>
+      (new UserStoryStepActionBuilder()..update(updates))._build();
+
+  _$UserStoryStepAction._(
+      {required this.id,
+      required this.createdAt,
+      this.updatedAt,
+      this.stepId,
+      this.targetId,
+      this.targetType,
+      this.description,
+      this.rank})
+      : super._() {
+    BuiltValueNullFieldError.checkNotNull(id, r'UserStoryStepAction', 'id');
+    BuiltValueNullFieldError.checkNotNull(
+        createdAt, r'UserStoryStepAction', 'createdAt');
+  }
+
+  @override
+  UserStoryStepAction rebuild(
+          void Function(UserStoryStepActionBuilder) updates) =>
+      (toBuilder()..update(updates)).build();
+
+  @override
+  UserStoryStepActionBuilder toBuilder() =>
+      new UserStoryStepActionBuilder()..replace(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(other, this)) return true;
+    return other is UserStoryStepAction &&
+        id == other.id &&
+        createdAt == other.createdAt &&
+        updatedAt == other.updatedAt &&
+        stepId == other.stepId &&
+        targetId == other.targetId &&
+        targetType == other.targetType &&
+        description == other.description &&
+        rank == other.rank;
+  }
+
+  @override
+  int get hashCode {
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, updatedAt.hashCode);
+    _$hash = $jc(_$hash, stepId.hashCode);
+    _$hash = $jc(_$hash, targetId.hashCode);
+    _$hash = $jc(_$hash, targetType.hashCode);
+    _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, rank.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
+  }
+
+  @override
+  String toString() {
+    return (newBuiltValueToStringHelper(r'UserStoryStepAction')
+          ..add('id', id)
+          ..add('createdAt', createdAt)
+          ..add('updatedAt', updatedAt)
+          ..add('stepId', stepId)
+          ..add('targetId', targetId)
+          ..add('targetType', targetType)
+          ..add('description', description)
+          ..add('rank', rank))
+        .toString();
+  }
+}
+
+class UserStoryStepActionBuilder
+    implements Builder<UserStoryStepAction, UserStoryStepActionBuilder> {
+  _$UserStoryStepAction? _$v;
+
+  String? _id;
+  String? get id => _$this._id;
+  set id(String? id) => _$this._id = id;
+
+  DateTime? _createdAt;
+  DateTime? get createdAt => _$this._createdAt;
+  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+
+  DateTime? _updatedAt;
+  DateTime? get updatedAt => _$this._updatedAt;
+  set updatedAt(DateTime? updatedAt) => _$this._updatedAt = updatedAt;
+
+  String? _stepId;
+  String? get stepId => _$this._stepId;
+  set stepId(String? stepId) => _$this._stepId = stepId;
+
+  String? _targetId;
+  String? get targetId => _$this._targetId;
+  set targetId(String? targetId) => _$this._targetId = targetId;
+
+  String? _targetType;
+  String? get targetType => _$this._targetType;
+  set targetType(String? targetType) => _$this._targetType = targetType;
+
+  String? _description;
+  String? get description => _$this._description;
+  set description(String? description) => _$this._description = description;
+
+  String? _rank;
+  String? get rank => _$this._rank;
+  set rank(String? rank) => _$this._rank = rank;
+
+  UserStoryStepActionBuilder();
+
+  UserStoryStepActionBuilder get _$this {
+    final $v = _$v;
+    if ($v != null) {
+      _id = $v.id;
+      _createdAt = $v.createdAt;
+      _updatedAt = $v.updatedAt;
+      _stepId = $v.stepId;
+      _targetId = $v.targetId;
+      _targetType = $v.targetType;
+      _description = $v.description;
+      _rank = $v.rank;
+      _$v = null;
+    }
+    return this;
+  }
+
+  @override
+  void replace(UserStoryStepAction other) {
+    ArgumentError.checkNotNull(other, 'other');
+    _$v = other as _$UserStoryStepAction;
+  }
+
+  @override
+  void update(void Function(UserStoryStepActionBuilder)? updates) {
+    if (updates != null) updates(this);
+  }
+
+  @override
+  UserStoryStepAction build() => _build();
+
+  _$UserStoryStepAction _build() {
+    final _$result = _$v ??
+        new _$UserStoryStepAction._(
+            id: BuiltValueNullFieldError.checkNotNull(
+                id, r'UserStoryStepAction', 'id'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(
+                createdAt, r'UserStoryStepAction', 'createdAt'),
+            updatedAt: updatedAt,
+            stepId: stepId,
+            targetId: targetId,
+            targetType: targetType,
+            description: description,
+            rank: rank);
+    replace(_$result);
+    return _$result;
+  }
+}
+
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -356,6 +356,57 @@ class ObjectRepository {
     }
   }
 
+  Future<List<Map<String, dynamic>>> getUserStorySteps({
+    required String storyId,
+  }) async {
+    try {
+      final results = await db.getAll(
+        '''
+        SELECT * FROM user_story_steps
+        WHERE story_id = ?
+        ORDER BY rank
+        ''',
+        [storyId],
+      );
+
+      return results
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+                {},
+                (res, e) => {...res, e.key: e.value},
+              ))
+          .toList();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getStepActions({
+    required String stepId,
+  }) async {
+    try {
+      final results = await db.getAll(
+        '''
+        SELECT sa.*, e.name AS element_name, sf.name AS function_name
+        FROM user_story_step_actions sa
+        LEFT JOIN elements e ON sa.target_id = e.id AND sa.target_type = 'element'
+        LEFT JOIN screen_functions sf ON sa.target_id = sf.id AND sa.target_type = 'screen_function'
+        WHERE sa.step_id = ?
+        ORDER BY sa.rank
+        ''',
+        [stepId],
+      );
+
+      return results
+          .map((r) => r.entries.fold<Map<String, dynamic>>(
+                {},
+                (res, e) => {...res, e.key: e.value},
+              ))
+          .toList();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   Future connectToExternalObject({
     required String objectType,
     required String objectId,

--- a/apps/apprm/lib/features/common_object/foundation/use_cases/get_step_actions_usecase.dart
+++ b/apps/apprm/lib/features/common_object/foundation/use_cases/get_step_actions_usecase.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../object_repository.dart';
+import 'common_usecase.dart';
+
+final getStepActionsProvider = Provider<GetStepActionsUseCase>(
+  (ref) => GetStepActionsUseCase(
+    objectRepository: ref.read(objectRepositoryProvider),
+  ),
+);
+
+class GetStepActionsUseCase
+    implements ParamsUseCase<Future<List<Map<String, dynamic>>>, GetStepActionsUseCaseParams> {
+  final ObjectRepository objectRepository;
+
+  GetStepActionsUseCase({required this.objectRepository});
+
+  @override
+  execute(params) {
+    return objectRepository.getStepActions(stepId: params.stepId);
+  }
+}
+
+class GetStepActionsUseCaseParams {
+  final String stepId;
+
+  GetStepActionsUseCaseParams({required this.stepId});
+}

--- a/apps/apprm/lib/features/common_object/foundation/use_cases/get_user_story_steps_usecase.dart
+++ b/apps/apprm/lib/features/common_object/foundation/use_cases/get_user_story_steps_usecase.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../object_repository.dart';
+import 'common_usecase.dart';
+
+final getUserStoryStepsProvider = Provider<GetUserStoryStepsUseCase>(
+  (ref) => GetUserStoryStepsUseCase(
+    objectRepository: ref.read(objectRepositoryProvider),
+  ),
+);
+
+class GetUserStoryStepsUseCase
+    implements ParamsUseCase<Future<List<Map<String, dynamic>>>, GetUserStoryStepsUseCaseParams> {
+  final ObjectRepository objectRepository;
+
+  GetUserStoryStepsUseCase({required this.objectRepository});
+
+  @override
+  execute(params) {
+    return objectRepository.getUserStorySteps(storyId: params.storyId);
+  }
+}
+
+class GetUserStoryStepsUseCaseParams {
+  final String storyId;
+
+  GetUserStoryStepsUseCaseParams({required this.storyId});
+}

--- a/apps/apprm/lib/features/common_object/mappers/user_story_step_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/user_story_step_mapper.dart
@@ -1,0 +1,21 @@
+import '../entities/object_item.dart';
+import '../foundation/models/user_story_step.dart';
+
+class UserStoryStepToObjectItemMapper {
+  static ObjectItem fromModel(UserStoryStep item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.name ?? '',
+      subTitle: item.description ?? '',
+      sortFields: const [
+        (key: 'name', label: 'Name'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(UserStoryStep.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -6,6 +6,8 @@ import 'package:apprm/features/screens/widgets/data_link_list.dart';
 import 'package:apprm/features/screens/widgets/element_list.dart';
 import 'package:apprm/features/screens/widgets/element_photo_list.dart';
 import 'package:apprm/features/screens/widgets/navigation_list.dart';
+import 'package:apprm/features/user_stories/widgets/story_step_list.dart';
+import 'package:apprm/features/user_stories/widgets/step_action_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -104,6 +106,15 @@ class ObjectDetailCard extends ConsumerWidget {
                 objectId: objectId,
                 objectType: 'element',
                 screenId: screenId,
+              ),
+            if (objectType == 'user_stories')
+              StoryStepList(
+                storyId: objectId,
+              ),
+            if (objectType == 'user_story_steps')
+              StepActionList(
+                appId: appId,
+                stepId: objectId,
               ),
           ],
         ),

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -15,6 +15,7 @@ import '../../common_object/mappers/data_field_mapper.dart';
 import '../../common_object/mappers/screen_function_mapper.dart';
 import '../../common_object/mappers/ui_element_mapper.dart';
 import '../../common_object/mappers/work_log_mapper.dart';
+import '../../common_object/mappers/user_story_step_mapper.dart';
 import '../../common_object/widgets/detail/object_detail_wrapper.dart';
 
 class ObjectDetailPage extends StatefulWidget {
@@ -81,6 +82,13 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
     ),
     'user_stories': (
       dataMapperFn: UserStoryToObjectItemMapper.fromJson,
+      displayFields: [
+        (key: 'name', label: 'Name'),
+        (key: 'description', label: 'Description'),
+      ],
+    ),
+    'user_story_steps': (
+      dataMapperFn: UserStoryStepToObjectItemMapper.fromJson,
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),

--- a/apps/apprm/lib/features/user_stories/pages/user_story_step_adding_page.dart
+++ b/apps/apprm/lib/features/user_stories/pages/user_story_step_adding_page.dart
@@ -1,0 +1,108 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_easyloading/flutter_easyloading.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+import '../../../constants/color.dart';
+import '../../common_object/foundation/object_repository.dart';
+
+class UserStoryStepAddingPage extends ConsumerStatefulWidget {
+  const UserStoryStepAddingPage({super.key, required this.appId, required this.storyId});
+
+  final String appId;
+  final String storyId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _UserStoryStepAddingPageState();
+}
+
+class _UserStoryStepAddingPageState extends ConsumerState<UserStoryStepAddingPage> {
+  late FormGroup formGroup;
+  final ObjectRepository _repository = ObjectRepository();
+
+  @override
+  void initState() {
+    formGroup = FormGroup({
+      'name': FormControl<String>(),
+      'description': FormControl<String>(),
+    });
+    super.initState();
+  }
+
+  Future<void> _save() async {
+    formGroup.markAllAsTouched();
+    if (formGroup.valid) {
+      try {
+        EasyLoading.show(status: 'Creating...');
+        await _repository.createObject(
+          tableName: 'user_story_steps',
+          data: {
+            'story_id': widget.storyId,
+            'name': formGroup.control('name').value,
+            'description': formGroup.control('description').value,
+          },
+        );
+        CachedQuery.instance.refetchQueries(keys: [
+          ['user_story_steps', 'list', widget.storyId]
+        ]);
+        if (context.mounted) {
+          context.pop(true);
+        }
+      } catch (e) {
+        EasyLoading.showError(e.toString());
+      } finally {
+        EasyLoading.dismiss();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: false,
+        title: const Text('New step'),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: TextButton.icon(
+              onPressed: _save,
+              icon: const Icon(PhosphorIconsBold.check),
+              label: const Text('Add'),
+              style: IconButton.styleFrom(
+                foregroundColor: AppColors.primaryColor,
+              ),
+            ),
+          )
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: ReactiveForm(
+          formGroup: formGroup,
+          child: Wrap(
+            runSpacing: 16,
+            children: [
+              const Text('Name'),
+              ReactiveTextField(
+                formControlName: 'name',
+                decoration: const InputDecoration(border: OutlineInputBorder()),
+              ),
+              const Text('Description'),
+              ReactiveTextField(
+                formControlName: 'description',
+                decoration: const InputDecoration(border: OutlineInputBorder()),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/user_stories/widgets/step_action_list.dart
+++ b/apps/apprm/lib/features/user_stories/widgets/step_action_list.dart
@@ -1,0 +1,203 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../constants/color.dart';
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/create_object_usecase.dart';
+import '../../common_object/foundation/use_cases/get_step_actions_usecase.dart';
+import '../../screens/widgets/element_selection.dart';
+import '../../screens/widgets/function_selection.dart';
+import '../../screens/widgets/screen_selection.dart';
+
+class StepActionList extends ConsumerStatefulWidget {
+  const StepActionList({super.key, required this.appId, required this.stepId});
+
+  final String appId;
+  final String stepId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _StepActionListState();
+}
+
+class _StepActionListState extends ConsumerState<StepActionList> {
+  final _createMutation = Mutation<void, CreateObjectUseCaseParams>(
+    queryFn: (params) => CreateObjectUseCase(
+      objectRepository: ObjectRepository(),
+    ).execute(params),
+  );
+
+  void _refresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['user_story_step_actions', 'list', widget.stepId]
+    ]);
+  }
+
+  Future<void> _addAction() async {
+    final option = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return SimpleDialog(
+          title: const Text('Add Action'),
+          children: [
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop('element'),
+              child: const Text('Element'),
+            ),
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop('function'),
+              child: const Text('Function'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (option == null) return;
+
+    final selectedScreen = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+      context: context,
+      builder: (_) => ScreenSelection(appId: widget.appId),
+    );
+    if (selectedScreen == null) return;
+
+    if (option == 'element') {
+      final selectedElement = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+        context: context,
+        builder: (_) => ElementSelection(screenId: selectedScreen['id']),
+      );
+      if (selectedElement == null) return;
+
+      await _createMutation.mutate(
+        CreateObjectUseCaseParams(
+          objectType: 'user_story_step_actions',
+          data: {
+            'step_id': widget.stepId,
+            'target_id': selectedElement['id'],
+            'target_type': 'element',
+          },
+        ),
+      );
+    } else if (option == 'function') {
+      final selectedFunction = await showCupertinoModalBottomSheet<Map<String, dynamic>?>(
+        context: context,
+        builder: (_) => FunctionSelection(screenId: selectedScreen['id']),
+      );
+      if (selectedFunction == null) return;
+
+      await _createMutation.mutate(
+        CreateObjectUseCaseParams(
+          objectType: 'user_story_step_actions',
+          data: {
+            'step_id': widget.stepId,
+            'target_id': selectedFunction['id'],
+            'target_type': 'screen_function',
+          },
+        ),
+      );
+    }
+
+    _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = widget.appId;
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Actions',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'user_story_step_actions',
+                  'list',
+                  widget.stepId,
+                ],
+                queryFn: () async {
+                  return await GetStepActionsUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetStepActionsUseCaseParams(stepId: widget.stepId),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: Duration(seconds: 1),
+                  refetchDuration: Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              final list = state.data ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (list.isEmpty)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...list.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final targetType = e['target_type'] as String?;
+                          final targetId = e['target_id'] as String?;
+                          if (targetType == null || targetId == null) return;
+                          await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: targetType == 'element'
+                                ? 'elements'
+                                : 'screen_functions',
+                            objectId: targetId,
+                          ).push(context);
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['target_type'] == 'element'
+                                ? (e['element_name'] ?? e['target_id'])
+                                : (e['function_name'] ?? e['target_id']),
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: _addAction,
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/features/user_stories/widgets/story_step_list.dart
+++ b/apps/apprm/lib/features/user_stories/widgets/story_step_list.dart
@@ -1,0 +1,128 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+import '../../../constants/color.dart';
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_user_story_steps_usecase.dart';
+
+class StoryStepList extends ConsumerStatefulWidget {
+  const StoryStepList({super.key, required this.storyId});
+
+  final String storyId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => _StoryStepListState();
+}
+
+class _StoryStepListState extends ConsumerState<StoryStepList> {
+  void _refresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['user_story_steps', 'list', widget.storyId]
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Steps',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+                key: [
+                  'user_story_steps',
+                  'list',
+                  widget.storyId,
+                ],
+                queryFn: () async {
+                  return await GetUserStoryStepsUseCase(
+                    objectRepository: ObjectRepository(),
+                  ).execute(
+                    GetUserStoryStepsUseCaseParams(storyId: widget.storyId),
+                  );
+                },
+                config: QueryConfig(
+                  cacheDuration: Duration(seconds: 1),
+                  refetchDuration: Duration(seconds: 1),
+                  storeQuery: false,
+                )),
+            builder: (context, state) {
+              final list = state.data ?? [];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (list.isEmpty)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...list.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final result = await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'user_story_steps',
+                            objectId: e['id'],
+                          ).push(context);
+                          if (result == true) {
+                            _refresh();
+                          }
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['name'] ?? '--',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: OutlinedButton.icon(
+                      onPressed: () async {
+                        await UserStoryStepAddingRoute(
+                          appId: appIdParam,
+                          storyId: widget.storyId,
+                        ).push(context);
+                        _refresh();
+                      },
+                      icon: const Icon(PhosphorIconsBold.plus),
+                      label: const Text(''),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppColors.primaryColor,
+                      ),
+                    ),
+                  )
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -22,6 +22,7 @@ import 'features/object/pages/object_detail_page.dart';
 import 'features/object/pages/object_listing_page.dart';
 import 'features/object/pages/object_updating_page.dart';
 import 'features/screens/pages/screen_element_adding_page.dart';
+import 'features/user_stories/pages/user_story_step_adding_page.dart';
 
 part 'router.g.dart';
 
@@ -274,6 +275,21 @@ class ScreenElementAddingRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return ScreenElementAddingPage(appId: appId, screenId: screenId);
+  }
+}
+
+@TypedGoRoute<UserStoryStepAddingRoute>(
+  path: '/app/:appId/user_stories/:storyId/steps/add',
+)
+class UserStoryStepAddingRoute extends GoRouteData {
+  const UserStoryStepAddingRoute({required this.appId, required this.storyId});
+
+  final String appId;
+  final String storyId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return UserStoryStepAddingPage(appId: appId, storyId: storyId);
   }
 }
 

--- a/apps/apprm/lib/router.g.dart
+++ b/apps/apprm/lib/router.g.dart
@@ -17,6 +17,7 @@ List<RouteBase> get $appRoutes => [
       $adminRoute,
       $objectListingRoute,
       $screenElementAddingRoute,
+      $userStoryStepAddingRoute,
       $externalObjectListingRoute,
       $notificationRoute,
     ];
@@ -427,6 +428,32 @@ extension $ScreenElementAddingRouteExtension on ScreenElementAddingRoute {
 
   String get location => GoRouteData.$location(
         '/app/${Uri.encodeComponent(appId)}/screens/${Uri.encodeComponent(screenId)}/elements/add',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $userStoryStepAddingRoute => GoRouteData.$route(
+      path: '/app/:appId/user_stories/:storyId/steps/add',
+      factory: $UserStoryStepAddingRouteExtension._fromState,
+    );
+
+extension $UserStoryStepAddingRouteExtension on UserStoryStepAddingRoute {
+  static UserStoryStepAddingRoute _fromState(GoRouterState state) =>
+      UserStoryStepAddingRoute(
+        appId: state.pathParameters['appId']!,
+        storyId: state.pathParameters['storyId']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/app/${Uri.encodeComponent(appId)}/user_stories/${Uri.encodeComponent(storyId)}/steps/add',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- add `user_story_steps` and `user_story_step_actions` tables to schema
- create built_value models for story steps and actions
- support listing and adding steps/actions
- wire steps and actions into object detail view
- add router and pages for creating steps

## Testing
- `flutter analyze`
- `flutter test` *(fails: Supabase not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6851902c451483219f356bf115861277