### PR TITLE
Add step action details with encrypted descriptions

### DIFF
--- a/apps/apprm/lib/features/common_object/mappers/user_story_step_action_mapper.dart
+++ b/apps/apprm/lib/features/common_object/mappers/user_story_step_action_mapper.dart
@@ -1,0 +1,23 @@
+import '../entities/object_item.dart';
+import '../foundation/models/user_story_step_action.dart';
+
+class UserStoryStepActionToObjectItemMapper {
+  static ObjectItem fromModel(UserStoryStepAction item, Map<String, dynamic> json) {
+    return ObjectItem(
+      id: item.id,
+      title: item.description ?? '',
+      subTitle: item.targetType == 'element'
+          ? (json['element_name'] ?? '')
+          : (json['function_name'] ?? ''),
+      sortFields: const [
+        (key: 'description', label: 'Description'),
+      ],
+      raw: item,
+      rawJson: json,
+    );
+  }
+
+  static ObjectItem fromJson(Map<String, dynamic> json) {
+    return fromModel(UserStoryStepAction.fromJson(json), json);
+  }
+}

--- a/apps/apprm/lib/features/user_stories/pages/step_action_detail_page.dart
+++ b/apps/apprm/lib/features/user_stories/pages/step_action_detail_page.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../router.dart';
+
+import '../../common_object/mappers/user_story_step_action_mapper.dart';
+import '../../common_object/widgets/detail/object_detail_wrapper.dart';
+import '../../common_object/widgets/managing/object_updating_wrapper.dart';
+
+class StepActionDetailPage extends StatelessWidget {
+  const StepActionDetailPage({super.key, required this.appId, required this.actionId});
+
+  final String appId;
+  final String actionId;
+
+  @override
+  Widget build(BuildContext context) {
+    return ObjectDetailWrapper(
+      objectType: 'user_story_step_actions',
+      objectId: actionId,
+      appId: appId,
+      mapperFn: UserStoryStepActionToObjectItemMapper.fromJson,
+      displayFields: const [
+        (key: 'description', label: 'Description'),
+        (key: 'element_name', label: 'Element'),
+        (key: 'function_name', label: 'Function'),
+      ],
+      onEditingNavigateFn: () {
+        StepActionUpdatingRoute(appId: appId, actionId: actionId).push(context);
+      },
+    );
+  }
+}
+
+class StepActionUpdatingPage extends StatelessWidget {
+  const StepActionUpdatingPage({super.key, required this.actionId});
+
+  final String actionId;
+
+  @override
+  Widget build(BuildContext context) {
+    return ObjectUpdatingWrapper(
+      objectType: 'user_story_step_actions',
+      objectId: actionId,
+      objectLabel: 'step action',
+      inputFields: const [
+        (key: 'description', label: 'Description', placeholder: null, displayMode: 'TEXT', options: null, asyncOptions: null),
+      ],
+    );
+  }
+}

--- a/apps/apprm/lib/router.dart
+++ b/apps/apprm/lib/router.dart
@@ -23,6 +23,7 @@ import 'features/object/pages/object_listing_page.dart';
 import 'features/object/pages/object_updating_page.dart';
 import 'features/screens/pages/screen_element_adding_page.dart';
 import 'features/user_stories/pages/user_story_step_adding_page.dart';
+import 'features/user_stories/pages/step_action_detail_page.dart';
 
 part 'router.g.dart';
 
@@ -290,6 +291,38 @@ class UserStoryStepAddingRoute extends GoRouteData {
   @override
   Widget build(BuildContext context, GoRouterState state) {
     return UserStoryStepAddingPage(appId: appId, storyId: storyId);
+  }
+}
+
+@TypedGoRoute<StepActionDetailRoute>(
+  path: '/app/:appId/step_actions/:actionId',
+  routes: [
+    TypedGoRoute<StepActionUpdatingRoute>(
+      path: 'update',
+    ),
+  ],
+)
+class StepActionDetailRoute extends GoRouteData {
+  const StepActionDetailRoute({required this.appId, required this.actionId});
+
+  final String appId;
+  final String actionId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return StepActionDetailPage(appId: appId, actionId: actionId);
+  }
+}
+
+class StepActionUpdatingRoute extends GoRouteData {
+  const StepActionUpdatingRoute({required this.appId, required this.actionId});
+
+  final String appId;
+  final String actionId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return StepActionUpdatingPage(actionId: actionId);
   }
 }
 

--- a/apps/apprm/lib/router.g.dart
+++ b/apps/apprm/lib/router.g.dart
@@ -18,6 +18,7 @@ List<RouteBase> get $appRoutes => [
       $objectListingRoute,
       $screenElementAddingRoute,
       $userStoryStepAddingRoute,
+      $stepActionDetailRoute,
       $externalObjectListingRoute,
       $notificationRoute,
     ];
@@ -454,6 +455,59 @@ extension $UserStoryStepAddingRouteExtension on UserStoryStepAddingRoute {
 
   String get location => GoRouteData.$location(
         '/app/${Uri.encodeComponent(appId)}/user_stories/${Uri.encodeComponent(storyId)}/steps/add',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $stepActionDetailRoute => GoRouteData.$route(
+      path: '/app/:appId/step_actions/:actionId',
+      factory: $StepActionDetailRouteExtension._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: 'update',
+          factory: $StepActionUpdatingRouteExtension._fromState,
+        ),
+      ],
+    );
+
+extension $StepActionDetailRouteExtension on StepActionDetailRoute {
+  static StepActionDetailRoute _fromState(GoRouterState state) =>
+      StepActionDetailRoute(
+        appId: state.pathParameters['appId']!,
+        actionId: state.pathParameters['actionId']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/app/${Uri.encodeComponent(appId)}/step_actions/${Uri.encodeComponent(actionId)}',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $StepActionUpdatingRouteExtension on StepActionUpdatingRoute {
+  static StepActionUpdatingRoute _fromState(GoRouterState state) =>
+      StepActionUpdatingRoute(
+        appId: state.pathParameters['appId']!,
+        actionId: state.pathParameters['actionId']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/app/${Uri.encodeComponent(appId)}/step_actions/${Uri.encodeComponent(actionId)}/update',
       );
 
   void go(BuildContext context) => context.go(location);


### PR DESCRIPTION
## Summary
- allow step action descriptions when creating actions
- list step actions by description and open detail page
- add StepActionDetailPage and Update page
- encrypt/decrypt user_story_step_action descriptions in repository
- register new routes and mapper for step action

## Testing
- `flutter analyze`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_685344dfed708321b9b154ada1b27770