### PR TITLE
Enable editing for element photos

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -11,6 +11,7 @@ const _encryptedNameDescriptionTables = {
   'screen_functions',
   'user_stories',
   'screen_photos',
+  'element_photos',
   'elements',
   'user_story_steps',
   'user_story_step_actions',

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -238,6 +238,27 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'element_photos': (
+      label: 'photo',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'user_stories': (
       label: 'user_story',
       inputFields: [


### PR DESCRIPTION
## Summary
- add encryption for `element_photos`
- support updating element photos in the generic object update page

## Testing
- `flutter pub get`
- `flutter test` *(fails: Supabase instance not initialized)*
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68555e3958f0832189f33a62c647246e