### PR TITLE
Fix element photo editing

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -282,6 +282,7 @@ Schema schema = Schema(
         Column.text('id'),
         Column.text('created_at'),
         Column.text('updated_at'),
+        Column.text('app_id'),
         Column.text('element_id'),
         Column.text('name'),
         Column.text('description'),

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -11,6 +11,7 @@ const _encryptedNameDescriptionTables = {
   'screen_functions',
   'user_stories',
   'screen_photos',
+  'element_photos',
   'elements',
   'user_story_steps',
   'user_story_step_actions',

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -238,6 +238,27 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'element_photos': (
+      label: 'photo',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'user_stories': (
       label: 'user_story',
       inputFields: [

--- a/apps/apprm/lib/features/screens/widgets/element_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/element_photo_list.dart
@@ -94,6 +94,7 @@ class _ElementPhotoListState extends ConsumerState<ElementPhotoList> {
       CreateObjectUseCaseParams(
         objectType: 'element_photos',
         data: {
+          'app_id': widget.appId,
           'element_id': widget.elementId,
           'name': file.name,
           'photo_id': photoId,


### PR DESCRIPTION
## Summary
- encrypt element photo fields
- allow editing element photos
- include app ID in element photo creation
- update local DB schema

## Testing
- `flutter analyze`
- `flutter test` *(fails: You must initialize the supabase instance before calling Supabase.instance)*

------
https://chatgpt.com/codex/tasks/task_e_68556730b4648321810a844d4599eff2