### PR TITLE
Add screen links on function and element detail pages

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/use_cases/get_element_screens_usecase.dart
+++ b/apps/apprm/lib/features/common_object/foundation/use_cases/get_element_screens_usecase.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../object_repository.dart';
+import 'common_usecase.dart';
+
+final getElementScreensProvider = Provider<GetElementScreensUseCase>(
+  (ref) => GetElementScreensUseCase(
+    objectRepository: ref.read(objectRepositoryProvider),
+  ),
+);
+
+class GetElementScreensUseCase
+    implements
+        ParamsUseCase<Future<List<Map<String, dynamic>>>,
+            GetElementScreensUseCaseParams> {
+  final ObjectRepository objectRepository;
+
+  GetElementScreensUseCase({required this.objectRepository});
+
+  @override
+  execute(params) {
+    return objectRepository.getElementScreens(elementId: params.elementId);
+  }
+}
+
+class GetElementScreensUseCaseParams {
+  final String elementId;
+
+  GetElementScreensUseCaseParams({required this.elementId});
+}

--- a/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
+++ b/apps/apprm/lib/features/common_object/widgets/detail/object_detail_card.dart
@@ -6,6 +6,8 @@ import 'package:apprm/features/screens/widgets/data_link_list.dart';
 import 'package:apprm/features/screens/widgets/element_list.dart';
 import 'package:apprm/features/screens/widgets/element_photo_list.dart';
 import 'package:apprm/features/screens/widgets/navigation_list.dart';
+import 'package:apprm/features/screens/widgets/element_screen_list.dart';
+import 'package:apprm/router.dart';
 import 'package:apprm/features/user_stories/widgets/story_step_list.dart';
 import 'package:apprm/features/user_stories/widgets/step_action_list.dart';
 import 'package:apprm/typedefs/display_field.dart';
@@ -63,6 +65,20 @@ class ObjectDetailCard extends ConsumerWidget {
                 ),
               ),
             ),
+            if (objectType == 'screen_functions')
+              _buildField(
+                'Screen',
+                objectItem?['screen_name'],
+                onTap: objectItem?['screen_id'] != null
+                    ? () async {
+                        await ObjectDetailRoute(
+                          appId: appId,
+                          objectType: 'screens',
+                          objectId: objectItem?['screen_id'],
+                        ).push(context);
+                      }
+                    : null,
+              ),
             if (objectType == 'people')
               ExternalSystemConnected(
                 objectType: objectType,
@@ -102,6 +118,10 @@ class ObjectDetailCard extends ConsumerWidget {
                 appId: appId,
               ),
             if (objectType == 'elements')
+              ElementScreenList(
+                elementId: objectId,
+              ),
+            if (objectType == 'elements')
               NavigationList(
                 appId: appId,
                 objectId: objectId,
@@ -119,6 +139,31 @@ class ObjectDetailCard extends ConsumerWidget {
               ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildField(String label, String? value, {VoidCallback? onTap}) {
+    final text = Text(
+      value ?? '--',
+      style: const TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          onTap != null ? InkWell(onTap: onTap, child: text) : text,
+        ],
       ),
     );
   }

--- a/apps/apprm/lib/features/screens/widgets/element_screen_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/element_screen_list.dart
@@ -1,0 +1,110 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../router.dart';
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_element_screens_usecase.dart';
+
+class ElementScreenList extends ConsumerStatefulWidget {
+  const ElementScreenList({super.key, required this.elementId});
+
+  final String elementId;
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _ElementScreenListState();
+}
+
+class _ElementScreenListState extends ConsumerState<ElementScreenList> {
+  void onRefresh() {
+    CachedQuery.instance.refetchQueries(keys: [
+      ['element_screens', 'list', widget.elementId]
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final appIdParam = GoRouterState.of(context).pathParameters['appId']!;
+
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Screens',
+            style: TextStyle(
+              color: Colors.black54,
+            ),
+          ),
+          QueryBuilder<List<Map<String, dynamic>>>(
+            query: Query(
+              key: [
+                'element_screens',
+                'list',
+                widget.elementId,
+              ],
+              queryFn: () async {
+                return await GetElementScreensUseCase(
+                  objectRepository: ObjectRepository(),
+                ).execute(
+                  GetElementScreensUseCaseParams(elementId: widget.elementId),
+                );
+              },
+              config: QueryConfig(
+                cacheDuration: Duration(seconds: 1),
+                refetchDuration: Duration(seconds: 1),
+                storeQuery: false,
+              ),
+            ),
+            builder: (context, state) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (state.data?.isEmpty ?? true)
+                    const Text(
+                      '--',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    )
+                  else
+                    ...state.data!.map(
+                      (e) => InkWell(
+                        onTap: () async {
+                          final result = await ObjectDetailRoute(
+                            appId: appIdParam,
+                            objectType: 'screens',
+                            objectId: e['id'],
+                          ).push(context);
+                          if (result == true) {
+                            onRefresh();
+                          }
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 8,
+                            horizontal: 12,
+                          ),
+                          child: Text(
+                            e['name'] ?? '--',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add API to fetch screens for an element
- show screen name link on function detail view
- list connected screens on element detail page

## Testing
- `flutter analyze`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_6856dde4a0d88321901f05a66f97ac2f