### PR TITLE
Fix edit form for user story steps

### DIFF
--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -280,6 +280,27 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         ),
       ],
     ),
+    'user_story_steps': (
+      label: 'step',
+      inputFields: [
+        (
+          key: 'name',
+          label: 'Name',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+      ],
+    ),
     'work_logs': (
       label: 'work log',
       inputFields: [


### PR DESCRIPTION
## Summary
- add config for editing `user_story_steps`

## Testing
- `dart format lib/features/object/pages/object_updating_page.dart`
- `flutter analyze`
- `flutter test` *(fails: Supabase instance not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6856dec2bd7083218540cc6bef1de65e