### PR TITLE
Add user story option for step actions

### DIFF
--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -134,12 +134,13 @@ class ObjectRepository {
           WHERE ss.id = ?''';
       } else if (tableName == 'user_story_step_actions') {
         query = '''
-          SELECT sa.*, us.app_id, e.name AS element_name, sf.name AS function_name
+          SELECT sa.*, us.app_id, e.name AS element_name, sf.name AS function_name, us2.name AS user_story_name
           FROM user_story_step_actions sa
           JOIN user_story_steps ss ON sa.step_id = ss.id
           JOIN user_stories us ON ss.story_id = us.id
           LEFT JOIN elements e ON sa.target_id = e.id AND sa.target_type = 'element'
           LEFT JOIN screen_functions sf ON sa.target_id = sf.id AND sa.target_type = 'screen_function'
+          LEFT JOIN user_stories us2 ON sa.target_id = us2.id AND sa.target_type = 'user_story'
           WHERE sa.id = ?''';
       } else if (tableName == 'screen_functions') {
         query = '''
@@ -491,12 +492,13 @@ class ObjectRepository {
     try {
       final results = await db.getAll(
         '''
-        SELECT sa.*, us.app_id, e.name AS element_name, sf.name AS function_name
+        SELECT sa.*, us.app_id, e.name AS element_name, sf.name AS function_name, us2.name AS user_story_name
         FROM user_story_step_actions sa
         JOIN user_story_steps ss ON sa.step_id = ss.id
         JOIN user_stories us ON ss.story_id = us.id
         LEFT JOIN elements e ON sa.target_id = e.id AND sa.target_type = 'element'
         LEFT JOIN screen_functions sf ON sa.target_id = sf.id AND sa.target_type = 'screen_function'
+        LEFT JOIN user_stories us2 ON sa.target_id = us2.id AND sa.target_type = 'user_story'
         WHERE sa.step_id = ?
         ORDER BY sa.rank
         ''',

--- a/apps/apprm/lib/features/user_stories/pages/step_action_detail_page.dart
+++ b/apps/apprm/lib/features/user_stories/pages/step_action_detail_page.dart
@@ -16,13 +16,15 @@ import '../../common_object/foundation/use_cases/delete_object_item_usecase.dart
 import '../../common_object/foundation/use_cases/get_object_item_usecase.dart';
 
 class StepActionDetailPage extends ConsumerStatefulWidget {
-  const StepActionDetailPage({super.key, required this.appId, required this.actionId});
+  const StepActionDetailPage(
+      {super.key, required this.appId, required this.actionId});
 
   final String appId;
   final String actionId;
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _StepActionDetailPageState();
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _StepActionDetailPageState();
 }
 
 class _StepActionDetailPageState extends ConsumerState<StepActionDetailPage> {
@@ -34,7 +36,7 @@ class _StepActionDetailPageState extends ConsumerState<StepActionDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    return QueryBuilder<Map<String, dynamic>>( 
+    return QueryBuilder<Map<String, dynamic>>(
       query: Query(
         key: [
           'user_story_step_actions',
@@ -59,8 +61,7 @@ class _StepActionDetailPageState extends ConsumerState<StepActionDetailPage> {
       ),
       builder: (context, state) {
         final title = state.data != null
-            ? UserStoryStepActionToObjectItemMapper.fromJson(state.data!)
-                .title
+            ? UserStoryStepActionToObjectItemMapper.fromJson(state.data!).title
             : '--';
 
         return Scaffold(
@@ -186,7 +187,14 @@ class StepActionUpdatingPage extends StatelessWidget {
       objectId: actionId,
       objectLabel: 'step action',
       inputFields: const [
-        (key: 'description', label: 'Description', placeholder: null, displayMode: 'TEXT', options: null, asyncOptions: null),
+        (
+          key: 'description',
+          label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null
+        ),
       ],
     );
   }
@@ -206,6 +214,7 @@ class StepActionDetailCard extends StatelessWidget {
   Widget build(BuildContext context) {
     String? elementName = action?['element_name'];
     String? functionName = action?['function_name'];
+    String? userStoryName = action?['user_story_name'];
     return Card(
       color: Colors.white,
       child: Container(
@@ -236,6 +245,19 @@ class StepActionDetailCard extends StatelessWidget {
                       await ObjectDetailRoute(
                         appId: appId,
                         objectType: 'screen_functions',
+                        objectId: action?['target_id'],
+                      ).push(context);
+                    }
+                  : null,
+            ),
+            _buildField(
+              'User Story',
+              userStoryName,
+              onTap: userStoryName != null
+                  ? () async {
+                      await ObjectDetailRoute(
+                        appId: appId,
+                        objectType: 'user_stories',
                         objectId: action?['target_id'],
                       ).push(context);
                     }

--- a/apps/apprm/lib/features/user_stories/widgets/user_story_selection.dart
+++ b/apps/apprm/lib/features/user_stories/widgets/user_story_selection.dart
@@ -1,0 +1,60 @@
+import 'package:cached_query_flutter/cached_query_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../common_object/foundation/object_repository.dart';
+import '../../common_object/foundation/use_cases/get_object_list_usecase.dart';
+
+class UserStorySelection extends ConsumerWidget {
+  const UserStorySelection(
+      {super.key, required this.appId, this.excludeStoryId});
+
+  final String appId;
+  final String? excludeStoryId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SafeArea(
+      child: SizedBox(
+        height: 400,
+        child: QueryBuilder<List<Map<String, dynamic>>>(
+          query: Query(
+            key: ['user_stories', 'select', appId],
+            queryFn: () async {
+              final list = await GetObjectListUseCase(
+                objectRepository: ObjectRepository(),
+              ).execute(
+                GetObjectListUseCaseParams(
+                  objectType: 'user_stories',
+                  sortValues: const {},
+                  filterValues: {'app_id': appId},
+                  searchFields: const ['name'],
+                ),
+              );
+              if (excludeStoryId != null) {
+                list.removeWhere((e) => e['id'] == excludeStoryId);
+              }
+              return list;
+            },
+          ),
+          builder: (context, state) {
+            final list = state.data ?? [];
+            return ListView.separated(
+              itemCount: list.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (_, idx) {
+                final item = list[idx];
+                return ListTile(
+                  title: Text(item['name'] ?? '--'),
+                  onTap: () {
+                    Navigator.of(context).pop(item);
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add ability to select a user story when creating step actions
- show linked user stories in step action lists and details
- fetch user story names from the DB

## Testing
- `flutter analyze`
- `flutter test` *(fails: Supabase instance not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6856ebaea3d48321b5dd388b5ef232db