### PR TITLE
Add prompt support for ideas and requirements

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -137,6 +137,7 @@ Schema schema = Schema(
         Column.text('app_id'),
         Column.text('requirement'),
         Column.text('description'),
+        Column.text('prompt'),
         Column.text('completed'),
         Column.text('completed_at'),
       ],
@@ -167,6 +168,7 @@ Schema schema = Schema(
         Column.text('app_id'),
         Column.text('name'),
         Column.text('description'),
+        Column.text('prompt'),
       ],
       indexes: [
         Index('ideas_list', [IndexedColumn('id')])

--- a/apps/apprm/lib/features/common_object/foundation/models/idea.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/idea.dart
@@ -21,6 +21,8 @@ abstract class Idea implements Built<Idea, IdeaBuilder> {
 
   String? get description;
 
+  String? get prompt;
+
   Idea._();
   factory Idea([void Function(IdeaBuilder) updates]) = _$Idea;
 

--- a/apps/apprm/lib/features/common_object/foundation/models/idea.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/idea.g.dart
@@ -21,37 +21,38 @@ class _$IdeaSerializer implements StructuredSerializer<Idea> {
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'created_at',
-      serializers.serialize(object.createdAt,
-          specifiedType: const FullType(DateTime)),
+      serializers.serialize(object.createdAt, specifiedType: const FullType(DateTime)),
     ];
     Object? value;
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updated_at')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(DateTime)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(DateTime)));
     }
     value = object.appId;
     if (value != null) {
       result
         ..add('app_id')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     value = object.name;
     if (value != null) {
       result
         ..add('name')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.prompt;
+    if (value != null) {
+      result
+        ..add('prompt')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     return result;
   }
@@ -68,28 +69,32 @@ class _$IdeaSerializer implements StructuredSerializer<Idea> {
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
-          result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
+          result.id =
+              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'created_at':
-          result.createdAt = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime))! as DateTime;
+          result.createdAt =
+              serializers.deserialize(value, specifiedType: const FullType(DateTime))! as DateTime;
           break;
         case 'updated_at':
-          result.updatedAt = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime)) as DateTime?;
+          result.updatedAt =
+              serializers.deserialize(value, specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'app_id':
-          result.appId = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.appId =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
         case 'name':
-          result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.name =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
         case 'description':
-          result.description = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.description =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'prompt':
+          result.prompt =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
       }
     }
@@ -111,6 +116,8 @@ class _$Idea extends Idea {
   final String? name;
   @override
   final String? description;
+  @override
+  final String? prompt;
 
   factory _$Idea([void Function(IdeaBuilder)? updates]) =>
       (new IdeaBuilder()..update(updates))._build();
@@ -121,15 +128,15 @@ class _$Idea extends Idea {
       this.updatedAt,
       this.appId,
       this.name,
-      this.description})
+      this.description,
+      this.prompt})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(id, r'Idea', 'id');
     BuiltValueNullFieldError.checkNotNull(createdAt, r'Idea', 'createdAt');
   }
 
   @override
-  Idea rebuild(void Function(IdeaBuilder) updates) =>
-      (toBuilder()..update(updates)).build();
+  Idea rebuild(void Function(IdeaBuilder) updates) => (toBuilder()..update(updates)).build();
 
   @override
   IdeaBuilder toBuilder() => new IdeaBuilder()..replace(this);
@@ -143,7 +150,8 @@ class _$Idea extends Idea {
         updatedAt == other.updatedAt &&
         appId == other.appId &&
         name == other.name &&
-        description == other.description;
+        description == other.description &&
+        prompt == other.prompt;
   }
 
   @override
@@ -155,6 +163,7 @@ class _$Idea extends Idea {
     _$hash = $jc(_$hash, appId.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, prompt.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -167,7 +176,8 @@ class _$Idea extends Idea {
           ..add('updatedAt', updatedAt)
           ..add('appId', appId)
           ..add('name', name)
-          ..add('description', description))
+          ..add('description', description)
+          ..add('prompt', prompt))
         .toString();
   }
 }
@@ -199,6 +209,10 @@ class IdeaBuilder implements Builder<Idea, IdeaBuilder> {
   String? get description => _$this._description;
   set description(String? description) => _$this._description = description;
 
+  String? _prompt;
+  String? get prompt => _$this._prompt;
+  set prompt(String? prompt) => _$this._prompt = prompt;
+
   IdeaBuilder();
 
   IdeaBuilder get _$this {
@@ -210,6 +224,7 @@ class IdeaBuilder implements Builder<Idea, IdeaBuilder> {
       _appId = $v.appId;
       _name = $v.name;
       _description = $v.description;
+      _prompt = $v.prompt;
       _$v = null;
     }
     return this;
@@ -233,12 +248,12 @@ class IdeaBuilder implements Builder<Idea, IdeaBuilder> {
     final _$result = _$v ??
         new _$Idea._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'Idea', 'id'),
-            createdAt: BuiltValueNullFieldError.checkNotNull(
-                createdAt, r'Idea', 'createdAt'),
+            createdAt: BuiltValueNullFieldError.checkNotNull(createdAt, r'Idea', 'createdAt'),
             updatedAt: updatedAt,
             appId: appId,
             name: name,
-            description: description);
+            description: description,
+            prompt: prompt);
     replace(_$result);
     return _$result;
   }

--- a/apps/apprm/lib/features/common_object/foundation/models/requirement.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/requirement.dart
@@ -21,6 +21,8 @@ abstract class Requirement implements Built<Requirement, RequirementBuilder> {
 
   String? get description;
 
+  String? get prompt;
+
   String? get completed;
 
   @BuiltValueField(wireName: 'completed_at')
@@ -36,4 +38,4 @@ abstract class Requirement implements Built<Requirement, RequirementBuilder> {
 
   Map<String, dynamic> toJson() =>
       serializers.serializeWith(serializer, this)! as Map<String, dynamic>;
-} 
+}

--- a/apps/apprm/lib/features/common_object/foundation/models/requirement.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/requirement.g.dart
@@ -21,51 +21,50 @@ class _$RequirementSerializer implements StructuredSerializer<Requirement> {
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
       'created_at',
-      serializers.serialize(object.createdAt,
-          specifiedType: const FullType(DateTime)),
+      serializers.serialize(object.createdAt, specifiedType: const FullType(DateTime)),
     ];
     Object? value;
     value = object.updatedAt;
     if (value != null) {
       result
         ..add('updated_at')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(DateTime)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(DateTime)));
     }
     value = object.appId;
     if (value != null) {
       result
         ..add('app_id')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     value = object.requirement;
     if (value != null) {
       result
         ..add('requirement')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     value = object.description;
     if (value != null) {
       result
         ..add('description')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
+    }
+    value = object.prompt;
+    if (value != null) {
+      result
+        ..add('prompt')
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     value = object.completed;
     if (value != null) {
       result
         ..add('completed')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(String)));
     }
     value = object.completedAt;
     if (value != null) {
       result
         ..add('completed_at')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(DateTime)));
+        ..add(serializers.serialize(value, specifiedType: const FullType(DateTime)));
     }
     return result;
   }
@@ -82,36 +81,40 @@ class _$RequirementSerializer implements StructuredSerializer<Requirement> {
       final Object? value = iterator.current;
       switch (key) {
         case 'id':
-          result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
+          result.id =
+              serializers.deserialize(value, specifiedType: const FullType(String))! as String;
           break;
         case 'created_at':
-          result.createdAt = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime))! as DateTime;
+          result.createdAt =
+              serializers.deserialize(value, specifiedType: const FullType(DateTime))! as DateTime;
           break;
         case 'updated_at':
-          result.updatedAt = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime)) as DateTime?;
+          result.updatedAt =
+              serializers.deserialize(value, specifiedType: const FullType(DateTime)) as DateTime?;
           break;
         case 'app_id':
-          result.appId = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.appId =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
         case 'requirement':
-          result.requirement = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.requirement =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
         case 'description':
-          result.description = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.description =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
+          break;
+        case 'prompt':
+          result.prompt =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
         case 'completed':
-          result.completed = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
+          result.completed =
+              serializers.deserialize(value, specifiedType: const FullType(String)) as String?;
           break;
         case 'completed_at':
-          result.completedAt = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime)) as DateTime?;
+          result.completedAt =
+              serializers.deserialize(value, specifiedType: const FullType(DateTime)) as DateTime?;
           break;
       }
     }
@@ -134,6 +137,8 @@ class _$Requirement extends Requirement {
   @override
   final String? description;
   @override
+  final String? prompt;
+  @override
   final String? completed;
   @override
   final DateTime? completedAt;
@@ -148,12 +153,12 @@ class _$Requirement extends Requirement {
       this.appId,
       this.requirement,
       this.description,
+      this.prompt,
       this.completed,
       this.completedAt})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(id, r'Requirement', 'id');
-    BuiltValueNullFieldError.checkNotNull(
-        createdAt, r'Requirement', 'createdAt');
+    BuiltValueNullFieldError.checkNotNull(createdAt, r'Requirement', 'createdAt');
   }
 
   @override
@@ -173,6 +178,7 @@ class _$Requirement extends Requirement {
         appId == other.appId &&
         requirement == other.requirement &&
         description == other.description &&
+        prompt == other.prompt &&
         completed == other.completed &&
         completedAt == other.completedAt;
   }
@@ -186,6 +192,7 @@ class _$Requirement extends Requirement {
     _$hash = $jc(_$hash, appId.hashCode);
     _$hash = $jc(_$hash, requirement.hashCode);
     _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, prompt.hashCode);
     _$hash = $jc(_$hash, completed.hashCode);
     _$hash = $jc(_$hash, completedAt.hashCode);
     _$hash = $jf(_$hash);
@@ -201,6 +208,7 @@ class _$Requirement extends Requirement {
           ..add('appId', appId)
           ..add('requirement', requirement)
           ..add('description', description)
+          ..add('prompt', prompt)
           ..add('completed', completed)
           ..add('completedAt', completedAt))
         .toString();
@@ -234,6 +242,10 @@ class RequirementBuilder implements Builder<Requirement, RequirementBuilder> {
   String? get description => _$this._description;
   set description(String? description) => _$this._description = description;
 
+  String? _prompt;
+  String? get prompt => _$this._prompt;
+  set prompt(String? prompt) => _$this._prompt = prompt;
+
   String? _completed;
   String? get completed => _$this._completed;
   set completed(String? completed) => _$this._completed = completed;
@@ -253,6 +265,7 @@ class RequirementBuilder implements Builder<Requirement, RequirementBuilder> {
       _appId = $v.appId;
       _requirement = $v.requirement;
       _description = $v.description;
+      _prompt = $v.prompt;
       _completed = $v.completed;
       _completedAt = $v.completedAt;
       _$v = null;
@@ -278,12 +291,13 @@ class RequirementBuilder implements Builder<Requirement, RequirementBuilder> {
     final _$result = _$v ??
         new _$Requirement._(
             id: BuiltValueNullFieldError.checkNotNull(id, r'Requirement', 'id'),
-            createdAt: BuiltValueNullFieldError.checkNotNull(
-                createdAt, r'Requirement', 'createdAt'),
+            createdAt:
+                BuiltValueNullFieldError.checkNotNull(createdAt, r'Requirement', 'createdAt'),
             updatedAt: updatedAt,
             appId: appId,
             requirement: requirement,
             description: description,
+            prompt: prompt,
             completed: completed,
             completedAt: completedAt);
     replace(_$result);

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -32,22 +32,19 @@ class ObjectRepository {
   }) async {
     var sortStatement = "";
     if (sortValues.isNotEmpty) {
-      final orderByKey =
-          sortValues.entries.map((e) => '${e.key} ${e.value}').join(', ');
+      final orderByKey = sortValues.entries.map((e) => '${e.key} ${e.value}').join(', ');
       sortStatement = " ORDER BY $orderByKey";
     }
 
     var filterStatement = "";
     if (filterValues.isNotEmpty) {
-      final conditionByKey = filterValues.entries
-          .map((e) => '${e.key}=\'${e.value}\'')
-          .join(' AND ');
+      final conditionByKey =
+          filterValues.entries.map((e) => '${e.key}=\'${e.value}\'').join(' AND ');
       filterStatement = " WHERE $conditionByKey";
     }
 
     if (searchValue?.isNotEmpty ?? false) {
-      final searchStatement =
-          searchFields.map((e) => '$e LIKE \'%$searchValue%\'').join(' OR ');
+      final searchStatement = searchFields.map((e) => '$e LIKE \'%$searchValue%\'').join(' OR ');
       if (filterStatement.isNotEmpty) {
         filterStatement = "$filterStatement $searchStatement";
       } else {
@@ -85,12 +82,11 @@ class ObjectRepository {
       final results = await db.getAll(query);
 
       final list = results
-          .map((r) => r.entries.fold<Map<String, dynamic>>(
-              {}, (res, e) => {...res, e.key: e.value}))
+          .map(
+              (r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
           .toList();
 
-      if (tableName == 'requirements' ||
-          _encryptedNameDescriptionTables.contains(tableName)) {
+      if (tableName == 'requirements' || _encryptedNameDescriptionTables.contains(tableName)) {
         for (var i = 0; i < list.length; i++) {
           if (tableName == 'requirements') {
             list[i] = await _decryptRequirementFields(list[i]);
@@ -151,11 +147,9 @@ class ObjectRepository {
       }
       final result = await db.get(query, [objectId]);
 
-      var map = result.entries
-          .fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value});
+      var map = result.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value});
 
-      if (tableName == 'requirements' ||
-          _encryptedNameDescriptionTables.contains(tableName)) {
+      if (tableName == 'requirements' || _encryptedNameDescriptionTables.contains(tableName)) {
         if (tableName == 'requirements') {
           map = await _decryptRequirementFields(map);
         } else {
@@ -177,8 +171,8 @@ class ObjectRepository {
       final results = await db.getAll('SELECT DISTINCT $field FROM $tableName');
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>(
-              {}, (res, e) => {...res, e.key: e.value}))
+          .map(
+              (r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -197,16 +191,14 @@ class ObjectRepository {
         if (appId != null) {
           data = await _encryptNameDescriptionFields(appId, data);
         }
-      } else if (tableName == 'user_story_step_actions' &&
-          data['step_id'] != null) {
+      } else if (tableName == 'user_story_step_actions' && data['step_id'] != null) {
         appId = await _getAppIdFromStep(data['step_id']);
         if (appId != null) {
           data = await _encryptNameDescriptionFields(appId, data);
         }
       } else if (tableName == 'requirements' && appId != null) {
         data = await _encryptRequirementFields(appId, data);
-      } else if (_encryptedNameDescriptionTables.contains(tableName) &&
-          appId != null) {
+      } else if (_encryptedNameDescriptionTables.contains(tableName) && appId != null) {
         data = await _encryptNameDescriptionFields(appId, data);
       }
       final fieldStatement = data.keys.map((e) => "'$e'").join(', ');
@@ -229,8 +221,7 @@ class ObjectRepository {
             }
           }
         }
-        final message =
-            'Created $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
+        final message = 'Created $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
         await _insertHistory(
           appId: appId,
           userId: getUserId(),
@@ -263,8 +254,7 @@ class ObjectRepository {
         }
       } else if (tableName == 'requirements' ||
           _encryptedNameDescriptionTables.contains(tableName)) {
-        final existing =
-            await getObjectItem(tableName: tableName, objectId: objectId);
+        final existing = await getObjectItem(tableName: tableName, objectId: objectId);
         final appId = existing['app_id'];
         if (appId != null) {
           if (tableName == 'requirements') {
@@ -274,8 +264,7 @@ class ObjectRepository {
           }
         }
       }
-      final setStatement =
-          data.entries.map((e) => "'${e.key}' = '${e.value ?? ''}'").join(', ');
+      final setStatement = data.entries.map((e) => "'${e.key}' = '${e.value ?? ''}'").join(', ');
       await db.execute(
         "UPDATE $tableName SET $setStatement WHERE id = ?",
         [objectId],
@@ -290,8 +279,7 @@ class ObjectRepository {
     required String objectId,
   }) async {
     try {
-      final item =
-          await getObjectItem(tableName: tableName, objectId: objectId);
+      final item = await getObjectItem(tableName: tableName, objectId: objectId);
       await db.execute(
         "DELETE FROM $tableName WHERE id = ?",
         [objectId],
@@ -300,8 +288,7 @@ class ObjectRepository {
       final appId = item['app_id'];
       if (appId != null) {
         final name = _extractName(item);
-        final message =
-            'Deleted $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
+        final message = 'Deleted $tableName${name.isNotEmpty ? ' \"$name\"' : ''}';
         await _insertHistory(
           appId: appId,
           userId: getUserId(),
@@ -324,8 +311,8 @@ class ObjectRepository {
       );
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>(
-              {}, (res, e) => {...res, e.key: e.value}))
+          .map(
+              (r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -347,8 +334,8 @@ class ObjectRepository {
       );
 
       return results
-          .map((r) => r.entries.fold<Map<String, dynamic>>(
-              {}, (res, e) => {...res, e.key: e.value}))
+          .map(
+              (r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
           .toList();
     } catch (e) {
       rethrow;
@@ -435,8 +422,8 @@ class ObjectRepository {
       );
 
       final list = results
-          .map((r) => r.entries.fold<Map<String, dynamic>>(
-              {}, (res, e) => {...res, e.key: e.value}))
+          .map(
+              (r) => r.entries.fold<Map<String, dynamic>>({}, (res, e) => {...res, e.key: e.value}))
           .toList();
 
       for (var i = 0; i < list.length; i++) {
@@ -585,8 +572,7 @@ class ObjectRepository {
   }
 
   String _extractName(Map<String, dynamic> data) {
-    return (data['name'] ?? data['requirement'] ?? data['description'] ?? '')
-        .toString();
+    return (data['name'] ?? data['requirement'] ?? data['description'] ?? '').toString();
   }
 
   Future<String?> _getAppSecret(String appId) async {
@@ -647,12 +633,13 @@ class ObjectRepository {
     if (secret == null) return data;
     final newData = Map<String, dynamic>.from(data);
     if (newData['requirement'] != null) {
-      newData['requirement'] =
-          executeEncrypt(newData['requirement'].toString(), secret);
+      newData['requirement'] = executeEncrypt(newData['requirement'].toString(), secret);
     }
     if (newData['description'] != null) {
-      newData['description'] =
-          executeEncrypt(newData['description'].toString(), secret);
+      newData['description'] = executeEncrypt(newData['description'].toString(), secret);
+    }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeEncrypt(newData['prompt'].toString(), secret);
     }
     return newData;
   }
@@ -666,39 +653,39 @@ class ObjectRepository {
       newData['name'] = executeEncrypt(newData['name'].toString(), secret);
     }
     if (newData['description'] != null) {
-      newData['description'] =
-          executeEncrypt(newData['description'].toString(), secret);
+      newData['description'] = executeEncrypt(newData['description'].toString(), secret);
+    }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeEncrypt(newData['prompt'].toString(), secret);
     }
     if (newData['type'] != null) {
       newData['type'] = executeEncrypt(newData['type'].toString(), secret);
     }
     if (newData['default_value'] != null) {
-      newData['default_value'] =
-          executeEncrypt(newData['default_value'].toString(), secret);
+      newData['default_value'] = executeEncrypt(newData['default_value'].toString(), secret);
     }
     return newData;
   }
 
-  Future<Map<String, dynamic>> _decryptRequirementFields(
-      Map<String, dynamic> data) async {
+  Future<Map<String, dynamic>> _decryptRequirementFields(Map<String, dynamic> data) async {
     final appId = data['app_id'];
     if (appId == null) return data;
     final secret = await _getAppSecret(appId);
     if (secret == null) return data;
     final newData = Map<String, dynamic>.from(data);
     if (newData['requirement'] != null) {
-      newData['requirement'] =
-          executeDecrypt(newData['requirement'].toString(), secret);
+      newData['requirement'] = executeDecrypt(newData['requirement'].toString(), secret);
     }
     if (newData['description'] != null) {
-      newData['description'] =
-          executeDecrypt(newData['description'].toString(), secret);
+      newData['description'] = executeDecrypt(newData['description'].toString(), secret);
+    }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeDecrypt(newData['prompt'].toString(), secret);
     }
     return newData;
   }
 
-  Future<Map<String, dynamic>> _decryptNameDescriptionFields(
-      Map<String, dynamic> data) async {
+  Future<Map<String, dynamic>> _decryptNameDescriptionFields(Map<String, dynamic> data) async {
     final appId = data['app_id'];
     if (appId == null) return data;
     final secret = await _getAppSecret(appId);
@@ -708,15 +695,16 @@ class ObjectRepository {
       newData['name'] = executeDecrypt(newData['name'].toString(), secret);
     }
     if (newData['description'] != null) {
-      newData['description'] =
-          executeDecrypt(newData['description'].toString(), secret);
+      newData['description'] = executeDecrypt(newData['description'].toString(), secret);
+    }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeDecrypt(newData['prompt'].toString(), secret);
     }
     if (newData['type'] != null) {
       newData['type'] = executeDecrypt(newData['type'].toString(), secret);
     }
     if (newData['default_value'] != null) {
-      newData['default_value'] =
-          executeDecrypt(newData['default_value'].toString(), secret);
+      newData['default_value'] = executeDecrypt(newData['default_value'].toString(), secret);
     }
 
     // decrypt any additional fields that end with `_name`

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -122,6 +122,14 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'prompt',
+          label: 'Prompt',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
       ],
     ),
     'screens': (
@@ -322,6 +330,14 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         (
           key: 'description',
           label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'prompt',
+          label: 'Prompt',
           placeholder: null,
           displayMode: 'TEXT',
           options: null,

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -50,6 +50,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'requirement', label: 'Requirement'),
         (key: 'description', label: 'Description'),
+        (key: 'prompt', label: 'Prompt'),
         (key: 'completed', label: 'Completed'),
       ],
     ),
@@ -58,6 +59,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),
+        (key: 'prompt', label: 'Prompt'),
       ],
     ),
     'screens': (
@@ -65,6 +67,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),
+        (key: 'prompt', label: 'Prompt'),
       ],
     ),
     'elements': (
@@ -138,12 +141,10 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    final objectTypeParam =
-        GoRouterState.of(context).pathParameters['objectType']!;
+    final objectTypeParam = GoRouterState.of(context).pathParameters['objectType']!;
     final objectIdParam = GoRouterState.of(context).pathParameters['objectId']!;
     final appIdParam = GoRouterState.of(context).pathParameters['appId'];
-    final screenIdParam =
-        GoRouterState.of(context).queryParameters['screen_id'];
+    final screenIdParam = GoRouterState.of(context).queryParameters['screen_id'];
     final objectData = objectDataMap[objectTypeParam];
 
     return ObjectDetailWrapper(
@@ -152,10 +153,8 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       appId: appIdParam!,
       screenId: screenIdParam,
       mapperFn: objectData?.dataMapperFn ?? (e) => ObjectItem.fromJson(e),
-      displayFields: objectData?.displayFields
-              .map((e) => (key: e.key, label: e.label))
-              .toList() ??
-          [],
+      displayFields:
+          objectData?.displayFields.map((e) => (key: e.key, label: e.label)).toList() ?? [],
       onEditingNavigateFn: () {
         ObjectUpdatingRoute(
           appId: appIdParam!,

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -124,6 +124,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
           asyncOptions: null,
         ),
         (
+          key: 'prompt',
+          label: 'Prompt',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
           key: 'completed',
           label: 'Completed',
           placeholder: null,
@@ -147,6 +155,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         (
           key: 'description',
           label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'prompt',
+          label: 'Prompt',
           placeholder: null,
           displayMode: 'TEXT',
           options: null,
@@ -450,8 +466,7 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
 
   @override
   Widget build(BuildContext context) {
-    final objectTypeParam =
-        GoRouterState.of(context).pathParameters['objectType']!;
+    final objectTypeParam = GoRouterState.of(context).pathParameters['objectType']!;
     final objectIdParam = GoRouterState.of(context).pathParameters['objectId']!;
     final objectData = objectDataMap[objectTypeParam];
 


### PR DESCRIPTION
## Summary
- update schema with `prompt` column for requirements and ideas
- encrypt/decrypt prompt fields in object repository
- extend models to include prompt
- add prompt to add/edit forms
- display prompt on detail page

## Testing
- `flutter pub get`
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_6856f08a56fc8321ae49b9d21a0b800b