### PR TITLE
Add prompt field for ideas and requirements

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -137,6 +137,7 @@ Schema schema = Schema(
         Column.text('app_id'),
         Column.text('requirement'),
         Column.text('description'),
+        Column.text('prompt'),
         Column.text('completed'),
         Column.text('completed_at'),
       ],
@@ -167,6 +168,7 @@ Schema schema = Schema(
         Column.text('app_id'),
         Column.text('name'),
         Column.text('description'),
+        Column.text('prompt'),
       ],
       indexes: [
         Index('ideas_list', [IndexedColumn('id')])

--- a/apps/apprm/lib/features/common_object/foundation/models/idea.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/idea.dart
@@ -21,6 +21,8 @@ abstract class Idea implements Built<Idea, IdeaBuilder> {
 
   String? get description;
 
+  String? get prompt;
+
   Idea._();
   factory Idea([void Function(IdeaBuilder) updates]) = _$Idea;
 

--- a/apps/apprm/lib/features/common_object/foundation/models/idea.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/idea.g.dart
@@ -53,6 +53,13 @@ class _$IdeaSerializer implements StructuredSerializer<Idea> {
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
+    value = object.prompt;
+    if (value != null) {
+      result
+        ..add('prompt')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
     return result;
   }
 
@@ -91,6 +98,10 @@ class _$IdeaSerializer implements StructuredSerializer<Idea> {
           result.description = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
           break;
+        case 'prompt':
+          result.prompt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
       }
     }
 
@@ -111,6 +122,8 @@ class _$Idea extends Idea {
   final String? name;
   @override
   final String? description;
+  @override
+  final String? prompt;
 
   factory _$Idea([void Function(IdeaBuilder)? updates]) =>
       (new IdeaBuilder()..update(updates))._build();
@@ -121,7 +134,8 @@ class _$Idea extends Idea {
       this.updatedAt,
       this.appId,
       this.name,
-      this.description})
+      this.description,
+      this.prompt})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(id, r'Idea', 'id');
     BuiltValueNullFieldError.checkNotNull(createdAt, r'Idea', 'createdAt');
@@ -143,7 +157,8 @@ class _$Idea extends Idea {
         updatedAt == other.updatedAt &&
         appId == other.appId &&
         name == other.name &&
-        description == other.description;
+        description == other.description &&
+        prompt == other.prompt;
   }
 
   @override
@@ -155,6 +170,7 @@ class _$Idea extends Idea {
     _$hash = $jc(_$hash, appId.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
     _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, prompt.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -167,7 +183,8 @@ class _$Idea extends Idea {
           ..add('updatedAt', updatedAt)
           ..add('appId', appId)
           ..add('name', name)
-          ..add('description', description))
+          ..add('description', description)
+          ..add('prompt', prompt))
         .toString();
   }
 }
@@ -199,6 +216,10 @@ class IdeaBuilder implements Builder<Idea, IdeaBuilder> {
   String? get description => _$this._description;
   set description(String? description) => _$this._description = description;
 
+  String? _prompt;
+  String? get prompt => _$this._prompt;
+  set prompt(String? prompt) => _$this._prompt = prompt;
+
   IdeaBuilder();
 
   IdeaBuilder get _$this {
@@ -210,6 +231,7 @@ class IdeaBuilder implements Builder<Idea, IdeaBuilder> {
       _appId = $v.appId;
       _name = $v.name;
       _description = $v.description;
+      _prompt = $v.prompt;
       _$v = null;
     }
     return this;
@@ -238,7 +260,8 @@ class IdeaBuilder implements Builder<Idea, IdeaBuilder> {
             updatedAt: updatedAt,
             appId: appId,
             name: name,
-            description: description);
+            description: description,
+            prompt: prompt);
     replace(_$result);
     return _$result;
   }

--- a/apps/apprm/lib/features/common_object/foundation/models/requirement.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/requirement.dart
@@ -21,6 +21,8 @@ abstract class Requirement implements Built<Requirement, RequirementBuilder> {
 
   String? get description;
 
+  String? get prompt;
+
   String? get completed;
 
   @BuiltValueField(wireName: 'completed_at')

--- a/apps/apprm/lib/features/common_object/foundation/models/requirement.g.dart
+++ b/apps/apprm/lib/features/common_object/foundation/models/requirement.g.dart
@@ -53,6 +53,13 @@ class _$RequirementSerializer implements StructuredSerializer<Requirement> {
         ..add(serializers.serialize(value,
             specifiedType: const FullType(String)));
     }
+    value = object.prompt;
+    if (value != null) {
+      result
+        ..add('prompt')
+        ..add(serializers.serialize(value,
+            specifiedType: const FullType(String)));
+    }
     value = object.completed;
     if (value != null) {
       result
@@ -105,6 +112,10 @@ class _$RequirementSerializer implements StructuredSerializer<Requirement> {
           result.description = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
           break;
+        case 'prompt':
+          result.prompt = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String?;
+          break;
         case 'completed':
           result.completed = serializers.deserialize(value,
               specifiedType: const FullType(String)) as String?;
@@ -134,6 +145,8 @@ class _$Requirement extends Requirement {
   @override
   final String? description;
   @override
+  final String? prompt;
+  @override
   final String? completed;
   @override
   final DateTime? completedAt;
@@ -148,6 +161,7 @@ class _$Requirement extends Requirement {
       this.appId,
       this.requirement,
       this.description,
+      this.prompt,
       this.completed,
       this.completedAt})
       : super._() {
@@ -173,6 +187,7 @@ class _$Requirement extends Requirement {
         appId == other.appId &&
         requirement == other.requirement &&
         description == other.description &&
+        prompt == other.prompt &&
         completed == other.completed &&
         completedAt == other.completedAt;
   }
@@ -186,6 +201,7 @@ class _$Requirement extends Requirement {
     _$hash = $jc(_$hash, appId.hashCode);
     _$hash = $jc(_$hash, requirement.hashCode);
     _$hash = $jc(_$hash, description.hashCode);
+    _$hash = $jc(_$hash, prompt.hashCode);
     _$hash = $jc(_$hash, completed.hashCode);
     _$hash = $jc(_$hash, completedAt.hashCode);
     _$hash = $jf(_$hash);
@@ -201,6 +217,7 @@ class _$Requirement extends Requirement {
           ..add('appId', appId)
           ..add('requirement', requirement)
           ..add('description', description)
+          ..add('prompt', prompt)
           ..add('completed', completed)
           ..add('completedAt', completedAt))
         .toString();
@@ -234,6 +251,10 @@ class RequirementBuilder implements Builder<Requirement, RequirementBuilder> {
   String? get description => _$this._description;
   set description(String? description) => _$this._description = description;
 
+  String? _prompt;
+  String? get prompt => _$this._prompt;
+  set prompt(String? prompt) => _$this._prompt = prompt;
+
   String? _completed;
   String? get completed => _$this._completed;
   set completed(String? completed) => _$this._completed = completed;
@@ -253,6 +274,7 @@ class RequirementBuilder implements Builder<Requirement, RequirementBuilder> {
       _appId = $v.appId;
       _requirement = $v.requirement;
       _description = $v.description;
+      _prompt = $v.prompt;
       _completed = $v.completed;
       _completedAt = $v.completedAt;
       _$v = null;
@@ -284,6 +306,7 @@ class RequirementBuilder implements Builder<Requirement, RequirementBuilder> {
             appId: appId,
             requirement: requirement,
             description: description,
+            prompt: prompt,
             completed: completed,
             completedAt: completedAt);
     replace(_$result);

--- a/apps/apprm/lib/features/common_object/foundation/object_repository.dart
+++ b/apps/apprm/lib/features/common_object/foundation/object_repository.dart
@@ -654,6 +654,9 @@ class ObjectRepository {
       newData['description'] =
           executeEncrypt(newData['description'].toString(), secret);
     }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeEncrypt(newData['prompt'].toString(), secret);
+    }
     return newData;
   }
 
@@ -668,6 +671,9 @@ class ObjectRepository {
     if (newData['description'] != null) {
       newData['description'] =
           executeEncrypt(newData['description'].toString(), secret);
+    }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeEncrypt(newData['prompt'].toString(), secret);
     }
     if (newData['type'] != null) {
       newData['type'] = executeEncrypt(newData['type'].toString(), secret);
@@ -694,6 +700,9 @@ class ObjectRepository {
       newData['description'] =
           executeDecrypt(newData['description'].toString(), secret);
     }
+    if (newData['prompt'] != null) {
+      newData['prompt'] = executeDecrypt(newData['prompt'].toString(), secret);
+    }
     return newData;
   }
 
@@ -710,6 +719,10 @@ class ObjectRepository {
     if (newData['description'] != null) {
       newData['description'] =
           executeDecrypt(newData['description'].toString(), secret);
+    }
+    if (newData['prompt'] != null) {
+      newData['prompt'] =
+          executeDecrypt(newData['prompt'].toString(), secret);
     }
     if (newData['type'] != null) {
       newData['type'] = executeDecrypt(newData['type'].toString(), secret);

--- a/apps/apprm/lib/features/object/pages/object_adding_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_adding_page.dart
@@ -122,6 +122,14 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'prompt',
+          label: 'Prompt',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
       ],
     ),
     'screens': (
@@ -322,6 +330,14 @@ class _ObjectAddingPageState extends State<ObjectAddingPage> {
         (
           key: 'description',
           label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'prompt',
+          label: 'Prompt',
           placeholder: null,
           displayMode: 'TEXT',
           options: null,

--- a/apps/apprm/lib/features/object/pages/object_detail_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_detail_page.dart
@@ -50,6 +50,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'requirement', label: 'Requirement'),
         (key: 'description', label: 'Description'),
+        (key: 'prompt', label: 'Prompt'),
         (key: 'completed', label: 'Completed'),
       ],
     ),
@@ -58,6 +59,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),
+        (key: 'prompt', label: 'Prompt'),
       ],
     ),
     'screens': (
@@ -107,6 +109,7 @@ class _ObjectDetailPageState extends State<ObjectDetailPage> {
       displayFields: [
         (key: 'name', label: 'Name'),
         (key: 'description', label: 'Description'),
+        (key: 'prompt', label: 'Prompt'),
       ],
     ),
     'data_objects': (

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -124,6 +124,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
           asyncOptions: null,
         ),
         (
+          key: 'prompt',
+          label: 'Prompt',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
           key: 'completed',
           label: 'Completed',
           placeholder: null,
@@ -147,6 +155,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
         (
           key: 'description',
           label: 'Description',
+          placeholder: null,
+          displayMode: 'TEXT',
+          options: null,
+          asyncOptions: null,
+        ),
+        (
+          key: 'prompt',
+          label: 'Prompt',
           placeholder: null,
           displayMode: 'TEXT',
           options: null,


### PR DESCRIPTION
## Summary
- extend DB schema for `prompt` column on ideas and requirements
- expose `prompt` on idea and requirement models
- encrypt/decrypt prompt data in `ObjectRepository`
- show prompt fields when adding or editing ideas and requirements
- display prompts in object detail views

## Testing
- `flutter pub get`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze` *(fails: The getter 'uri' isn't defined for the class 'GoRouterState')*
- `flutter test` *(fails to compile project)*

------
https://chatgpt.com/codex/tasks/task_e_6856f08a56fc8321ae49b9d21a0b800b