### PR TITLE
Add screen photo categories

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -231,6 +231,7 @@ Schema schema = Schema(
         Column.text('description'),
         Column.text('path'),
         Column.text('photo_id'),
+        Column.text('category'),
       ],
       indexes: [
         Index('screen_photos_list', [IndexedColumn('id')])

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -160,6 +160,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'category',
+          label: 'Category',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['current', 'prototype', 'archive'],
+          asyncOptions: null,
+        ),
       ],
     ),
     'screens': (

--- a/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
@@ -33,6 +33,8 @@ class ScreenPhotoList extends ConsumerStatefulWidget {
 class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
   final ImagePicker _picker = ImagePicker();
   String? _secret;
+  String _selectedCategory = 'current';
+  final List<String> _categories = ['current', 'prototype', 'archive'];
 
   @override
   void initState() {
@@ -61,7 +63,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
 
   void _refresh() {
     CachedQuery.instance.refetchQueries(keys: [
-      ['screen_photos', 'list', widget.screenId]
+      ['screen_photos', 'list', widget.screenId, _selectedCategory]
     ]);
   }
 
@@ -98,6 +100,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
           'screen_id': widget.screenId,
           'name': file.name,
           'photo_id': photoId,
+          'category': 'current',
         },
       ),
     );
@@ -217,12 +220,32 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
               color: Colors.black54,
             ),
           ),
+          DropdownButton<String>(
+            value: _selectedCategory,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() {
+                  _selectedCategory = value;
+                });
+                _refresh();
+              }
+            },
+            items: _categories
+                .map(
+                  (e) => DropdownMenuItem(
+                    value: e,
+                    child: Text(e),
+                  ),
+                )
+                .toList(),
+          ),
           QueryBuilder<List<Map<String, dynamic>>>(
-            query: Query(
+          query: Query(
                 key: [
                   'screen_photos',
                   'list',
                   widget.screenId,
+                  _selectedCategory,
                 ],
                 queryFn: () async {
                   return await GetObjectListUseCase(
@@ -231,7 +254,10 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
                     GetObjectListUseCaseParams(
                       objectType: 'screen_photos',
                       sortValues: const {},
-                      filterValues: {'screen_id': widget.screenId},
+                      filterValues: {
+                        'screen_id': widget.screenId,
+                        'category': _selectedCategory,
+                      },
                       searchFields: const ['name'],
                     ),
                   );


### PR DESCRIPTION
## Summary
- add `category` column to the `screen_photos` table
- allow category edit when updating screen photos
- default new screen photos to `current`
- filter screen photos by category with dropdown

## Testing
- `flutter test` *(fails: Supabase instance not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6858169b8c588321ac8b1733731219f3