### PR TITLE
Add screen photo categories and filtering

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -231,6 +231,7 @@ Schema schema = Schema(
         Column.text('description'),
         Column.text('path'),
         Column.text('photo_id'),
+        Column.text('category'),
       ],
       indexes: [
         Index('screen_photos_list', [IndexedColumn('id')])

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -244,6 +244,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'category',
+          label: 'Category',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['current', 'prototype', 'archive'],
+          asyncOptions: null,
+        ),
       ],
     ),
     'element_photos': (


### PR DESCRIPTION
## Summary
- extend schema to include a `category` column on `screen_photos`
- set default category when uploading photos
- allow selecting and filtering photo categories
- expose `category` on screen photo edit form

## Testing
- `flutter analyze` *(fails: 93 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_6858169b8c588321ac8b1733731219f3