### PR TITLE
Support screen photo categories

### DIFF
--- a/apps/apprm/lib/databases/schema.dart
+++ b/apps/apprm/lib/databases/schema.dart
@@ -229,6 +229,7 @@ Schema schema = Schema(
         Column.text('screen_id'),
         Column.text('name'),
         Column.text('description'),
+        Column.text('category'),
         Column.text('path'),
         Column.text('photo_id'),
       ],

--- a/apps/apprm/lib/features/object/pages/object_updating_page.dart
+++ b/apps/apprm/lib/features/object/pages/object_updating_page.dart
@@ -181,6 +181,14 @@ class _ObjectUpdatingPageState extends State<ObjectUpdatingPage> {
           options: null,
           asyncOptions: null,
         ),
+        (
+          key: 'category',
+          label: 'Category',
+          placeholder: null,
+          displayMode: 'SINGLE_SELECT',
+          options: ['current', 'prototype', 'archive'],
+          asyncOptions: null,
+        ),
       ],
     ),
     'elements': (

--- a/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
+++ b/apps/apprm/lib/features/screens/widgets/screen_photo_list.dart
@@ -33,6 +33,8 @@ class ScreenPhotoList extends ConsumerStatefulWidget {
 class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
   final ImagePicker _picker = ImagePicker();
   String? _secret;
+  static const _categories = ['current', 'prototype', 'archive'];
+  String _selectedCategory = 'current';
 
   @override
   void initState() {
@@ -61,7 +63,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
 
   void _refresh() {
     CachedQuery.instance.refetchQueries(keys: [
-      ['screen_photos', 'list', widget.screenId]
+      ['screen_photos', 'list', widget.screenId, _selectedCategory]
     ]);
   }
 
@@ -97,6 +99,7 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
           'app_id': widget.appId,
           'screen_id': widget.screenId,
           'name': file.name,
+          'category': 'current',
           'photo_id': photoId,
         },
       ),
@@ -217,12 +220,27 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
               color: Colors.black54,
             ),
           ),
+          DropdownButton<String>(
+            value: _selectedCategory,
+            onChanged: (v) {
+              if (v != null) {
+                setState(() {
+                  _selectedCategory = v;
+                });
+                _refresh();
+              }
+            },
+            items: _categories
+                .map((e) => DropdownMenuItem(value: e, child: Text(e)))
+                .toList(),
+          ),
           QueryBuilder<List<Map<String, dynamic>>>(
             query: Query(
                 key: [
                   'screen_photos',
                   'list',
                   widget.screenId,
+                  _selectedCategory,
                 ],
                 queryFn: () async {
                   return await GetObjectListUseCase(
@@ -231,7 +249,10 @@ class _ScreenPhotoListState extends ConsumerState<ScreenPhotoList> {
                     GetObjectListUseCaseParams(
                       objectType: 'screen_photos',
                       sortValues: const {},
-                      filterValues: {'screen_id': widget.screenId},
+                      filterValues: {
+                        'screen_id': widget.screenId,
+                        'category': _selectedCategory
+                      },
                       searchFields: const ['name'],
                     ),
                   );


### PR DESCRIPTION
## Summary
- add `category` column to screen photos schema
- default new screen photos to the `current` category
- allow editing screen photo category with a single-select field
- filter screen photos by category and let users switch between categories

## Testing
- `flutter analyze`
- `flutter test` *(fails: Multiple exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_68583ed9507083218a05730d2da54711